### PR TITLE
Add VM and Server List

### DIFF
--- a/app/api/vmapi.rb
+++ b/app/api/vmapi.rb
@@ -23,6 +23,13 @@ class VmApi
     end
   end
 
+  def all_hosts
+    connect
+    @hosts.map do |host|
+      { name: host.name, stats: host.stats, cores: host.summary[:numCpuCores], threads: host.summary[:numCpuThreads] }
+    end
+  end
+
   def delete_vm(name)
     connect
     vm = find_vm(name)

--- a/app/api/vmapi.rb
+++ b/app/api/vmapi.rb
@@ -110,7 +110,21 @@ class VmApi
     @vim = RbVmomi::VIM.connect(host: API_SERVER_IP, user: API_SERVER_USER, password: API_SERVER_PASSWORD, insecure: true)
     @dc = @vim.serviceInstance.find_datacenter('Datacenter') || raise('datacenter not found')
     @vm_folder = @dc.vmFolder
-    @hosts = @dc.hostFolder.children
+    @host_folder = @dc.hostFolder
+    @hosts = extract_hosts(@host_folder).flatten
+    @vms = @vm_folder.children
     @resource_pool = @hosts.first.resourcePool
+  end
+
+  def extract_hosts(element)
+    if element.class == RbVmomi::VIM::Folder
+      a = []
+      element.children.each do |child|
+        a << extract_hosts(child)
+      end
+      a
+    else
+      [element]
+    end
   end
 end

--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -4,6 +4,7 @@ require 'vmapi.rb'
 class VmController < ApplicationController
   def index
     @vms = VmApi.new.all_vms
+    @hosts = VmApi.new.all_hosts
   end
 
   def destroy

--- a/app/views/vm/index.html.erb
+++ b/app/views/vm/index.html.erb
@@ -2,14 +2,51 @@
   Virtual Machines
   <small class="text-muted">This is the overview page for all currently existing vms</small>
 </h1>
-<ul class="list-group">
+
+<table class="table">
+  <thead>
+  <tr>
+    <th scope="col">VM Name</th>
+    <th scope="col">Running Since</th>
+    <th scope="col">Delete</th>
+  </tr>
+  </thead>
+  <tbody>
   <% @vms.each do |vm| %>
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span class="col-4"><%= vm[:name]%></span>
-        <span class="col-4">Running since: <%= vm[:boot_time]%></span>
-        <div class="col-1"><%= button_to "Delete",
-                           {controller: :vm, action: 'destroy', id: vm[:name] },
-                           method: :delete, class: "btn btn-danger" %></div>
-      </li>
+    <tr>
+      <th scope="row"><%= vm[:name]%></th>
+      <td><%= vm[:boot_time]%></td>
+      <td><%= button_to "Delete",
+                        {controller: :vm, action: 'destroy', id: vm[:name] },
+                        method: :delete, class: "btn btn-danger" %></td>
+    <tr>
   <% end %>
-</ul>
+  </tbody>
+</table>
+
+<br>
+
+<table class="table">
+  <thead>
+  <tr>
+    <th scope="col">Hostname</th>
+    <th scope="col">Cores</th>
+    <th scope="col">Threads</th>
+    <th scope="col">Used CPU [%]</th>
+    <th scope="col">Available Memory [GB]</th>
+    <th scope="col">Used Memory [GB]</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @hosts.each do |host| %>
+    <tr>
+      <th scope="row"><%= host[:name]%></th>
+      <td><%= host[:cores]%></td>
+      <td><%= host[:threads]%></td>
+      <td><%= (Float(host[:stats][:usedCPU]) / Float(host[:stats][:totalCPU]) * 100.00).round(2)%> </td>
+      <td><%= (Float( host[:stats][:totalMem]) / 1000).round(2)%></td>
+      <td><%= (Float( host[:stats][:usedMem]) / 1000).round(2)%></td>
+    <tr>
+  <% end %>
+  </tbody>
+</table>

--- a/spec/api/apiwrapper_spec.rb
+++ b/spec/api/apiwrapper_spec.rb
@@ -60,15 +60,16 @@ RSpec.describe VmApi do
   end
 
   describe 'all_hosts' do
+    subject { api.all_hosts }
+
     let(:hosts_mock) do
       [] # @hosts contains all hosts as an array
     end
-    before :each do
+
+    before do
       allow(api).to receive(:connect)
       api.instance_variable_set :@hosts, hosts_mock
     end
-
-    subject {api.all_hosts}
 
     it 'asks @hosts for all hosts' do
       api.all_hosts

--- a/spec/api/apiwrapper_spec.rb
+++ b/spec/api/apiwrapper_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe VmApi do
     end
   end
 
+  describe 'all_hosts' do
+    let(:hosts_mock) do
+      [] # @hosts contains all hosts as an array
+    end
+    before :each do
+      allow(api).to receive(:connect)
+      api.instance_variable_set :@hosts, hosts_mock
+    end
+
+    subject {api.all_hosts}
+
+    it 'asks @hosts for all hosts' do
+      api.all_hosts
+    end
+
+    it 'responds with an array' do
+      expect(subject.class).to equal Array
+    end
+  end
+
   describe '#delete_vm' do
     let(:vm_mock) do
       mock = double

--- a/spec/controllers/vm_controller_spec.rb
+++ b/spec/controllers/vm_controller_spec.rb
@@ -8,17 +8,13 @@ RSpec.describe VmController, type: :controller do
     before :each do
       double_api = double
       expect(double_api).to receive(:all_vms).and_return [{name:'My insanely cool vm', state: true, boot_time: 'Thursday'}]
-      expect(double_api).to receive(:all_hosts).and_return [{
-                                                                name: 'someHostMachine',
-                                                                cores: 99,
-                                                                threads: 99,
-                                                                stats: {
-                                                                    usedCPU: 3,
-                                                                    totalCPU: 4,
-                                                                    usedMem: 5,
-                                                                    totalMem: 6
-                                                                }
-                                                            }]
+      allow(double_api).to receive(:all_hosts).and_return [{  name: 'someHostMachine',
+                                                              cores: 99,
+                                                              threads: 99,
+                                                              stats: {  usedCPU: 3,
+                                                                        totalCPU: 4,
+                                                                        usedMem: 5,
+                                                                        totalMem: 6 } }]
       allow(VmApi).to receive(:new).and_return double_api
     end
 

--- a/spec/controllers/vm_controller_spec.rb
+++ b/spec/controllers/vm_controller_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe VmController, type: :controller do
     before :each do
       double_api = double
       expect(double_api).to receive(:all_vms).and_return [{name:'My insanely cool vm', state: true, boot_time: 'Thursday'}]
+      expect(double_api).to receive(:all_hosts).and_return [{
+                                                                name: 'someHostMachine',
+                                                                cores: 99,
+                                                                threads: 99,
+                                                                stats: {
+                                                                    usedCPU: 3,
+                                                                    totalCPU: 4,
+                                                                    usedMem: 5,
+                                                                    totalMem: 6
+                                                                }
+                                                            }]
       allow(VmApi).to receive(:new).and_return double_api
     end
 

--- a/spec/views/vm/index.html.erb_spec.rb
+++ b/spec/views/vm/index.html.erb_spec.rb
@@ -10,9 +10,23 @@ RSpec.describe 'vm/index.html.erb', type: :view do
         boot_time: 'Yesterday'
     }
   end
+  let(:host) do
+    {
+        name: 'someHostMachine',
+        cores: 99,
+        threads: 99,
+        stats: {
+            usedCPU: 33,
+            totalCPU: 44,
+            usedMem: 5777,
+            totalMem: 63536
+        }
+    }
+  end
 
   before :each do
     assign(:vms, [vm])
+    assign(:hosts, [host])
     render
   end
 
@@ -22,5 +36,20 @@ RSpec.describe 'vm/index.html.erb', type: :view do
 
   it 'renders the boot time' do
     expect(rendered).to include vm[:boot_time]
+  end
+
+  it 'renders the host machine name' do
+    expect(rendered).to include host[:name]
+  end
+
+  it 'calculates host information' do
+    expect(rendered).to include (Float(host[:stats][:usedCPU]) / Float(host[:stats][:totalCPU]) * 100.00).round(2).to_s
+    expect(rendered).to include ((host[:stats][:usedMem] / 1000).round(2)).to_s
+    expect(rendered).to include ((host[:stats][:totalMem] / 1000).round(2)).to_s
+  end
+
+  it 'renders host information' do
+    expect(rendered).to include host[:cores].to_s
+    expect(rendered).to include host[:threads].to_s
   end
 end

--- a/spec/views/vm/index.html.erb_spec.rb
+++ b/spec/views/vm/index.html.erb_spec.rb
@@ -11,17 +11,13 @@ RSpec.describe 'vm/index.html.erb', type: :view do
     }
   end
   let(:host) do
-    {
-        name: 'someHostMachine',
-        cores: 99,
-        threads: 99,
-        stats: {
-            usedCPU: 33,
-            totalCPU: 44,
-            usedMem: 5777,
-            totalMem: 63536
-        }
-    }
+    {  name: 'someHostMachine',
+       cores: 99,
+       threads: 99,
+       stats: {  usedCPU: 33,
+                 totalCPU: 44,
+                 usedMem: 5777,
+                 totalMem: 6336 } }
   end
 
   before :each do
@@ -42,14 +38,23 @@ RSpec.describe 'vm/index.html.erb', type: :view do
     expect(rendered).to include host[:name]
   end
 
-  it 'calculates host information' do
-    expect(rendered).to include (Float(host[:stats][:usedCPU]) / Float(host[:stats][:totalCPU]) * 100.00).round(2).to_s
-    expect(rendered).to include ((host[:stats][:usedMem] / 1000).round(2)).to_s
-    expect(rendered).to include ((host[:stats][:totalMem] / 1000).round(2)).to_s
+  it 'calculates host cpu usage' do
+    expect(rendered).to include((Float(host[:stats][:usedCPU]) / Float(host[:stats][:totalCPU]) * 100.00).round(2).to_s)
   end
 
-  it 'renders host information' do
+  it 'renders used RAM' do
+    expect(rendered).to include((host[:stats][:usedMem] / 1000).round(2).to_s)
+  end
+
+  it 'renders available RAM' do
+    expect(rendered).to include((host[:stats][:totalMem] / 1000).round(2).to_s)
+  end
+
+  it 'renders host cpu cores' do
     expect(rendered).to include host[:cores].to_s
+  end
+
+  it 'renders host cpu threads' do
     expect(rendered).to include host[:threads].to_s
   end
 end


### PR DESCRIPTION
This MR adds a method to the provided `vSphere API` to request all `hosts`, as well as a view displaying the data retrieved from vSphere (as per #27 ).

A host consists of
- a `name`
- a number of `cores`
- a number of  `threads`
- stats containing total and available `CPU` and  total and available `RAM`, allowing to calculate usage percentages.

Additionally, this MR restructures the `VM` view.
The behaviour can be tested by visiting `localhost:3000/vm`.