### PR TITLE
Remove Details Button, add Timeslot Button

### DIFF
--- a/app/views/server/index.html.erb
+++ b/app/views/server/index.html.erb
@@ -36,6 +36,7 @@
     <th scope="col" data-sortable="true">Status</th>
     <th scope="col" data-sortable="true">Running Since</th>
     <th scope="col">VMs</th>
+    <th scope="col">timeslot reservation</th>
   </tr>
   </thead>
   <tbody>
@@ -57,6 +58,9 @@
                end %>
         </ul>
       </td>
+      <td><%= button_to "Reserve",
+                        "",
+                        method: :get, class: "btn btn-info" %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/server/index.html.erb
+++ b/app/views/server/index.html.erb
@@ -36,13 +36,14 @@
     <th scope="col" data-sortable="true">Status</th>
     <th scope="col" data-sortable="true">Running Since</th>
     <th scope="col">VMs</th>
-    <th scope="col">Details</th>
   </tr>
   </thead>
   <tbody>
   <% @hosts.each do |host| %>
     <tr>
-      <td><%= host[:name] %></td>
+      <td><%= link_to host[:name], 
+                      {controller: :server, action: 'show', id: host[:name]},
+                      method: :get, class: "btn btn-link" %></td>
       <td><%= host[:model] %></td>
       <td><%= host[:vendor] %></td>
       <td><%= host[:connectionState] %></td>
@@ -56,9 +57,6 @@
                end %>
         </ul>
       </td>
-      <td><%= button_to "Details",
-                        {controller: :server, action: 'show', id: host[:name]},
-                        method: :get, class: "btn btn-info" %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/server/index.html.erb
+++ b/app/views/server/index.html.erb
@@ -36,7 +36,7 @@
     <th scope="col" data-sortable="true">Status</th>
     <th scope="col" data-sortable="true">Running Since</th>
     <th scope="col">VMs</th>
-    <th scope="col">timeslot reservation</th>
+    <th scope="col">Timeslot Reservation</th>
   </tr>
   </thead>
   <tbody>

--- a/app/views/server/show.html.erb
+++ b/app/views/server/show.html.erb
@@ -94,6 +94,11 @@
     <% end unless @host.nil?%>
     </td>
     </tr>
+    <tr>
+      <td><%= button_to "Reserve",
+                        "",
+                        method: :get, class: "btn btn-info" %></td>
+    </tr>
 
   </tbody>
 </table>

--- a/app/views/vm/index.html.erb
+++ b/app/views/vm/index.html.erb
@@ -39,18 +39,16 @@
   <tr>
     <th scope="col" data-sortable="true">VM Name</th>
     <th scope="col" data-sortable="true">Running Since</th>
-    <th scope="col">Details</th>
     <th scope="col">Delete</th>
   </tr>
   </thead>
   <tbody>
   <% @vms.each do |vm| %>
     <tr>
-      <td><%= vm[:name] %></td>
+      <td><%= link_to vm[:name], 
+                      {controller: :vm, action: 'show', id: vm[:name]},
+                      method: :get, class: "btn btn-link"  %></td>
       <td><%= vm[:boot_time] %></td>
-      <td><%= button_to "Details",
-                        {controller: :vm, action: 'show', id: vm[:name]},
-                        method: :get, class: "btn btn-info" %></td>
       <td><%= button_to "Delete",
                         {controller: :vm, action: 'destroy', id: vm[:name]},
                         method: :delete, class: "btn btn-danger" %></td>

--- a/spec/views/server/index.html.erb_spec.rb
+++ b/spec/views/server/index.html.erb_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'server/index.html.erb', type: :view do
   end
 
   it 'links to resource detail pages' do
-    expect(rendered).to have_button('Details', count: 1)
+    expect(rendered).to have_link(host[:name], count: 1)
   end
 
   it 'can filter resources' do

--- a/spec/views/server/index.html.erb_spec.rb
+++ b/spec/views/server/index.html.erb_spec.rb
@@ -54,4 +54,8 @@ RSpec.describe 'server/index.html.erb', type: :view do
   it 'can filter resources' do
     expect(rendered).to have_button('Filter')
   end
+
+  it 'has reserve button' do
+    expect(rendered).to have_button('Reserve')
+  end
 end

--- a/spec/views/server/show.html.erb_spec.rb
+++ b/spec/views/server/show.html.erb_spec.rb
@@ -50,4 +50,8 @@ RSpec.describe 'server/show.html.erb', type: :view do
       expect(rendered).to include vm
     end
   end
+
+  it 'has reserve button' do
+    expect(rendered).to have_button('Reserve')
+  end
 end

--- a/spec/views/vm/index.html.erb_spec.rb
+++ b/spec/views/vm/index.html.erb_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'vm/index.html.erb', type: :view do
   end
 
   it 'links to resource detail pages' do
-    expect(rendered).to have_button('Details', count: 1)
+    expect(rendered).to have_link(vm[:name], count: 1)
   end
 
   it 'can filter resources' do


### PR DESCRIPTION
For issue #72 
- Remove Details Button on Overview Pages and instead link the name to Details Page.

- Add timeslot reservation button for server without destination (does nothing)