### PR TITLE
Add Errbit configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,11 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # https://coveralls.io/github/hpi-swt2/vm-portal
 gem 'coveralls', require: false
 
+# Report errors in production to central Errbit system
+# https://github.com/errbit/errbit
+# https://github.com/airbrake/airbrake
+gem 'airbrake', '~> 5.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    airbrake (5.8.1)
+      airbrake-ruby (~> 1.8)
+    airbrake-ruby (1.8.0)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -377,6 +380,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (~> 5.0)
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Therefore, the application is deployed on university servers. Both the 'dev' and
 
 An overview of the status of all involved systems is available here: https://stats.uptimerobot.com/j8DADFQnv
 
+### Deployment Error Collection
+Errors that occur in the deployed systems are reported to a central [Errbit](https://github.com/errbit/errbit) error collection application. It can be found here:
+* https://errbit-vm-portal.herokuapp.com/ [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m781561200-ca855387a43778c5060db064.svg)](https://stats.uptimerobot.com/j8DADFQnv)
+
+You can login using your GitHub credentials.
+
 ### Deployment Details
 Automatic deployments are handled by a dedicated application:
 * http://hart-deploy.epic-hpi.de/deployed [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m781547341-373d600b6052559e47f208f6.svg)](https://stats.uptimerobot.com/j8DADFQnv)

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,0 +1,9 @@
+Airbrake.configure do |config|
+  config.host = 'https://errbit-vm-portal.herokuapp.com'
+  config.project_id = 1 # required, but any positive integer works
+  config.project_key = ENV['ERRBIT_PROJCT_KEY'] || '7442c4230459a58a49afb8a0bcaff0a8'
+
+  # for Rails apps
+  config.environment = Rails.env
+  config.ignore_environments = %w(development test)
+end

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 Airbrake.configure do |config|
   config.host = 'https://errbit-vm-portal.herokuapp.com'
   config.project_id = 1 # required, but any positive integer works
-  config.project_key = ENV['ERRBIT_PROJCT_KEY'] || '7442c4230459a58a49afb8a0bcaff0a8'
+  config.project_key = ENV['ERRBIT_PROJECT_KEY'] || '7442c4230459a58a49afb8a0bcaff0a8'
 
   # for Rails apps
   config.environment = Rails.env


### PR DESCRIPTION
This PR adds the configuration necessary for the deployed application to report errors in production to a central Errbit error logging application running at https://errbit-vm-portal.herokuapp.com/