### PR TITLE
47/oldies/handle hpi network errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-# Allows dot-access of hashes
-gem 'hash_dot', '~> 2.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,6 @@ GEM
       pry (>= 0.9.12)
       shellany (~> 0.0)
       thor (>= 0.18.1)
-    hash_dot (2.4.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.1.1)
@@ -398,7 +397,6 @@ DEPENDENCIES
   faker!
   font-awesome-rails
   guard
-  hash_dot (~> 2.4.1)
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/api/vmapi.rb
+++ b/app/api/vmapi.rb
@@ -13,11 +13,6 @@ class VmApi
   API_SERVER_USER = 'administrator@swt.local'
   API_SERVER_PASSWORD = 'Vcsaswt"2018'
 
-  @is_connected = false
-  def connected?
-    @is_connected
-  end
-
   def create_vm(cpu, ram, capacity, name)
     connect
     vm_config = creation_config(cpu, ram, capacity, name)
@@ -27,14 +22,14 @@ class VmApi
   def all_vms
     connect
     @vm_folder.children.map do |vm|
-      { name: vm.name, state: (vm.runtime.powerState == 'poweredOn'), boot_time: vm.runtime.bootTime }
+      {name: vm.name, state: (vm.runtime.powerState == 'poweredOn'), boot_time: vm.runtime.bootTime}
     end
   end
 
   def all_clusters
     connect
     @clusters.map do |cluster|
-      { name: cluster.name, stats: cluster.stats, cores: cluster.summary[:numCpuCores], threads: cluster.summary[:numCpuThreads] }
+      {name: cluster.name, stats: cluster.stats, cores: cluster.summary[:numCpuCores], threads: cluster.summary[:numCpuThreads]}
     end
   end
 
@@ -47,13 +42,13 @@ class VmApi
         host.vm.map do |vm|
           vm_names << vm.name
         end
-        @hosts << { name: host.name,
-                    vm_names: vm_names,
-                    model: host.hardware.systemInfo.model,
-                    vendor: host.hardware.systemInfo.vendor,
-                    bootTime: host.runtime.bootTime,
-                    connectionState: host.runtime.connectionState,
-                    summary: host.summary }
+        @hosts << {name: host.name,
+                   vm_names: vm_names,
+                   model: host.hardware.systemInfo.model,
+                   vendor: host.hardware.systemInfo.vendor,
+                   bootTime: host.runtime.bootTime,
+                   connectionState: host.runtime.connectionState,
+                   summary: host.summary}
       end
     end
     @hosts
@@ -61,13 +56,11 @@ class VmApi
 
   def get_vm(name)
     connect
-    if @is_connected && (vm = find_vm(name))
-      { name: vm.name,
-        boot_time: vm.runtime.bootTime,
-        host: vm.summary.runtime.host.name,
-        guestHeartbeatStatus: vm.guestHeartbeatStatus,
-        summary: vm.summary }
-    end
+    {name: vm.name,
+     boot_time: vm.runtime.bootTime,
+     host: vm.summary.runtime.host.name,
+     guestHeartbeatStatus: vm.guestHeartbeatStatus,
+     summary: vm.summary}
   end
 
   def get_host(name)
@@ -98,59 +91,59 @@ class VmApi
   private
 
   def find_vm(name)
-    @vm_folder.traverse(name, RbVmomi:: VIM::VirtualMachine)
+    @vm_folder.traverse(name, RbVmomi::VIM::VirtualMachine)
   end
 
   def creation_config(cpu, ram, capacity, name) # rubocop:disable Metrics/MethodLength
     {
-      name: name,
-      guestId: 'otherGuest',
-      files: { vmPathName: '[Datastore]' },
-      numCPUs: cpu,
-      memoryMB: ram,
-      deviceChange: [
-        {
-          operation: :add,
-          device: RbVmomi::VIM.VirtualLsiLogicController(
-            key: 1000,
-            busNumber: 0,
-            sharedBus: :noSharing
-          )
-        }, {
-          operation: :add,
-          fileOperation: :create,
-          device: RbVmomi::VIM.VirtualDisk(
-            key: 0,
-            backing: RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
-              fileName: '[Datastore]',
-              diskMode: :persistent,
-              thinProvisioned: true
-            ),
-            controllerKey: 1000,
-            unitNumber: 0,
-            capacityInKB: capacity
-          )
-        }, {
-          operation: :add,
-          device: RbVmomi::VIM.VirtualE1000(
-            key: 0,
-            deviceInfo: {
-              label: 'Network Adapter 1',
-              summary: 'VM Network'
-            },
-            backing: RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
-              deviceName: 'VM Network'
-            ),
-            addressType: 'generated'
-          )
-        }
-      ],
-      extraConfig: [
-        {
-          key: 'bios.bootOrder',
-          value: 'ethernet0'
-        }
-      ]
+        name: name,
+        guestId: 'otherGuest',
+        files: {vmPathName: '[Datastore]'},
+        numCPUs: cpu,
+        memoryMB: ram,
+        deviceChange: [
+            {
+                operation: :add,
+                device: RbVmomi::VIM.VirtualLsiLogicController(
+                    key: 1000,
+                    busNumber: 0,
+                    sharedBus: :noSharing
+                )
+            }, {
+                operation: :add,
+                fileOperation: :create,
+                device: RbVmomi::VIM.VirtualDisk(
+                    key: 0,
+                    backing: RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
+                        fileName: '[Datastore]',
+                        diskMode: :persistent,
+                        thinProvisioned: true
+                    ),
+                    controllerKey: 1000,
+                    unitNumber: 0,
+                    capacityInKB: capacity
+                )
+            }, {
+                operation: :add,
+                device: RbVmomi::VIM.VirtualE1000(
+                    key: 0,
+                    deviceInfo: {
+                        label: 'Network Adapter 1',
+                        summary: 'VM Network'
+                    },
+                    backing: RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
+                        deviceName: 'VM Network'
+                    ),
+                    addressType: 'generated'
+                )
+            }
+        ],
+        extraConfig: [
+            {
+                key: 'bios.bootOrder',
+                value: 'ethernet0'
+            }
+        ]
     }
   end
 
@@ -162,21 +155,6 @@ class VmApi
     @clusters = extract_clusters(@cluster_folder).flatten
     @vms = @vm_folder.children
     @resource_pool = @clusters.first.resourcePool
-    @is_connected = true
-  rescue Net::OpenTimeout, Errno::ENETUNREACH, TimeOutError
-    instanciate_empty_vm_info
-  end
-
-  def instanciate_empty_vm_info
-    @is_connected = false
-    folder = {}
-    folder['children'] = {}
-    folder['traverse'] = -> {}
-    @vm_folder = folder.to_dot
-    @cluster_folder = []
-    @clusters = []
-    @vms = []
-    @resource_pool = []
   end
 
   def extract_clusters(element)

--- a/app/api/vmapi.rb
+++ b/app/api/vmapi.rb
@@ -21,14 +21,14 @@ class VmApi
   def all_vms
     connect
     @vm_folder.children.map do |vm|
-      {name: vm.name, state: (vm.runtime.powerState == 'poweredOn'), boot_time: vm.runtime.bootTime}
+      { name: vm.name, state: (vm.runtime.powerState == 'poweredOn'), boot_time: vm.runtime.bootTime }
     end
   end
 
   def all_clusters
     connect
     @clusters.map do |cluster|
-      {name: cluster.name, stats: cluster.stats, cores: cluster.summary[:numCpuCores], threads: cluster.summary[:numCpuThreads]}
+      { name: cluster.name, stats: cluster.stats, cores: cluster.summary[:numCpuCores], threads: cluster.summary[:numCpuThreads] }
     end
   end
 
@@ -41,13 +41,13 @@ class VmApi
         host.vm.map do |vm|
           vm_names << vm.name
         end
-        @hosts << {name: host.name,
-                   vm_names: vm_names,
-                   model: host.hardware.systemInfo.model,
-                   vendor: host.hardware.systemInfo.vendor,
-                   bootTime: host.runtime.bootTime,
-                   connectionState: host.runtime.connectionState,
-                   summary: host.summary}
+        @hosts << { name: host.name,
+                    vm_names: vm_names,
+                    model: host.hardware.systemInfo.model,
+                    vendor: host.hardware.systemInfo.vendor,
+                    bootTime: host.runtime.bootTime,
+                    connectionState: host.runtime.connectionState,
+                    summary: host.summary }
       end
     end
     @hosts
@@ -97,54 +97,54 @@ class VmApi
 
   def creation_config(cpu, ram, capacity, name) # rubocop:disable Metrics/MethodLength
     {
-        name: name,
-        guestId: 'otherGuest',
-        files: {vmPathName: '[Datastore]'},
-        numCPUs: cpu,
-        memoryMB: ram,
-        deviceChange: [
-            {
-                operation: :add,
-                device: RbVmomi::VIM.VirtualLsiLogicController(
-                    key: 1000,
-                    busNumber: 0,
-                    sharedBus: :noSharing
-                )
-            }, {
-                operation: :add,
-                fileOperation: :create,
-                device: RbVmomi::VIM.VirtualDisk(
-                    key: 0,
-                    backing: RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
-                        fileName: '[Datastore]',
-                        diskMode: :persistent,
-                        thinProvisioned: true
-                    ),
-                    controllerKey: 1000,
-                    unitNumber: 0,
-                    capacityInKB: capacity
-                )
-            }, {
-                operation: :add,
-                device: RbVmomi::VIM.VirtualE1000(
-                    key: 0,
-                    deviceInfo: {
-                        label: 'Network Adapter 1',
-                        summary: 'VM Network'
-                    },
-                    backing: RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
-                        deviceName: 'VM Network'
-                    ),
-                    addressType: 'generated'
-                )
-            }
-        ],
-        extraConfig: [
-            {
-                key: 'bios.bootOrder',
-                value: 'ethernet0'
-            }
-        ]
+      name: name,
+      guestId: 'otherGuest',
+      files: { vmPathName: '[Datastore]' },
+      numCPUs: cpu,
+      memoryMB: ram,
+      deviceChange: [
+        {
+          operation: :add,
+          device: RbVmomi::VIM.VirtualLsiLogicController(
+            key: 1000,
+            busNumber: 0,
+            sharedBus: :noSharing
+          )
+        }, {
+          operation: :add,
+          fileOperation: :create,
+          device: RbVmomi::VIM.VirtualDisk(
+            key: 0,
+            backing: RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
+              fileName: '[Datastore]',
+              diskMode: :persistent,
+              thinProvisioned: true
+            ),
+            controllerKey: 1000,
+            unitNumber: 0,
+            capacityInKB: capacity
+          )
+        }, {
+          operation: :add,
+          device: RbVmomi::VIM.VirtualE1000(
+            key: 0,
+            deviceInfo: {
+              label: 'Network Adapter 1',
+              summary: 'VM Network'
+            },
+            backing: RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
+              deviceName: 'VM Network'
+            ),
+            addressType: 'generated'
+          )
+        }
+      ],
+      extraConfig: [
+        {
+          key: 'bios.bootOrder',
+          value: 'ethernet0'
+        }
+      ]
     }
   end
 

--- a/app/api/vmapi.rb
+++ b/app/api/vmapi.rb
@@ -56,11 +56,13 @@ class VmApi
 
   def get_vm(name)
     connect
-    {name: vm.name,
-     boot_time: vm.runtime.bootTime,
-     host: vm.summary.runtime.host.name,
-     guestHeartbeatStatus: vm.guestHeartbeatStatus,
-     summary: vm.summary}
+    if (vm = find_vm(name))
+      { name: vm.name,
+        boot_time: vm.runtime.bootTime,
+        host: vm.summary.runtime.host.name,
+        guestHeartbeatStatus: vm.guestHeartbeatStatus,
+        summary: vm.summary }
+    end
   end
 
   def get_host(name)

--- a/app/api/vmapi.rb
+++ b/app/api/vmapi.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rbvmomi'
-require 'hash_dot'
 require 'singleton'
 # This class manages a connection to the VSphere backend
 # For rbvmomi documentation see: https://github.com/vmware/rbvmomi/tree/master/examples

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,6 @@ class ApplicationController < ActionController::Base
   rescue_from Net::OpenTimeout, Errno::ENETUNREACH, with: :error_render_method
 
   def error_render_method
-    render template: 'errors/timeout', status: 408 and return
+    render(template: 'errors/timeout', status: 408) && return
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
     vms_path
   end
 
-  rescue_from Net::OpenTimeout, Errno::ENETUNREACH, with: :error_render_method
+  rescue_from Net::OpenTimeout, Errno::ENETUNREACH, Errno::EHOSTUNREACH, with: :error_render_method
 
   def error_render_method
     render(template: 'errors/timeout', status: 408) && return

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,10 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_resource)
     vms_path
   end
+
+  rescue_from Net::OpenTimeout, Errno::ENETUNREACH, with: :error_render_method
+
+  def error_render_method
+    render template: 'errors/timeout', status: 404 and return
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,6 @@ class ApplicationController < ActionController::Base
   rescue_from Net::OpenTimeout, Errno::ENETUNREACH, with: :error_render_method
 
   def error_render_method
-    render template: 'errors/timeout', status: 404 and return
+    render template: 'errors/timeout', status: 408 and return
   end
 end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -7,22 +7,12 @@ class ServersController < ApplicationController
   def index
     @hosts = filter VmApi.instance.all_hosts
     @parameters = determine_params
-    if VmApi.instance.connected?
-      flash.discard
-    else
-      flash[:danger] = 'You seem to have lost connection to the HPI network :('
-    end
   end
 
   def new; end
 
   def show
-    if VmApi.instance.connected?
-      flash.discard
-      @host = VmApi.instance.get_host(params[:id])
-    else
-      flash[:danger] = 'You seem to have lost connection to the HPI network :('
-    end
+    @host = VmApi.instance.get_host(params[:id])
   end
 
   private

--- a/app/controllers/vms_controller.rb
+++ b/app/controllers/vms_controller.rb
@@ -7,32 +7,23 @@ class VmsController < ApplicationController
   def index
     @vms = filter VmApi.instance.all_vms
     @parameters = determine_params
-    if VmApi.instance.connected?
-      flash.discard
-    else
-      flash[:danger] = 'You seem to have lost connection to the HPI network :('
-    end
   end
 
   def destroy
     # params[:id] is actually the name of the vm, since the vsphere backend doesn't identify vms by IDs
-    VmApi.instance.delete_vm(params[:id]) if VmApi.instance.connected?
+    VmApi.instance.delete_vm(params[:id])
   end
 
   def create
-    VmApi.instance.create_vm(params[:cpu], params[:ram], params[:capacity], params[:name]) if VmApi.instance.connected?
+    VmApi.instance.create_vm(params[:cpu], params[:ram], params[:capacity], params[:name])
     redirect_to action: :index
   end
 
-  def new; end
+  def new;
+  end
 
   def show
-    if VmApi.instance.connected?
-      flash.discard
-      @vm = VmApi.instance.get_vm(params[:id])
-    else
-      flash[:danger] = 'You seem to have lost connection to the HPI network :('
-    end
+    @vm = VmApi.instance.get_vm(params[:id])
   end
 
   # This controller doesn't use strong parameters
@@ -42,11 +33,12 @@ class VmsController < ApplicationController
   private
 
   def filter(list)
-    if no_params_set? then list
+    if no_params_set? then
+      list
     else
       result = []
       vm_filter.keys.each do |key|
-        result += list.select { |object| vm_filter[key].call(object) } if params[key].present?
+        result += list.select {|object| vm_filter[key].call(object)} if params[key].present?
       end
       result
     end
@@ -56,8 +48,10 @@ class VmsController < ApplicationController
     all_parameters = vm_filter.keys.map(&:to_s)
     actual_params = params.keys.map(&:to_s)
     if no_params_set?
-    then all_parameters
-    else all_parameters - (all_parameters - actual_params)
+    then
+      all_parameters
+    else
+      all_parameters - (all_parameters - actual_params)
     end
   end
 
@@ -68,6 +62,6 @@ class VmsController < ApplicationController
   end
 
   def vm_filter
-    { up_vms: proc { |vm| vm[:state] }, down_vms: proc { |vm| !vm[:state] } }
+    {up_vms: proc {|vm| vm[:state]}, down_vms: proc {|vm| !vm[:state]}}
   end
 end

--- a/app/controllers/vms_controller.rb
+++ b/app/controllers/vms_controller.rb
@@ -19,8 +19,7 @@ class VmsController < ApplicationController
     redirect_to action: :index
   end
 
-  def new;
-  end
+  def new; end
 
   def show
     @vm = VmApi.instance.get_vm(params[:id])
@@ -33,12 +32,12 @@ class VmsController < ApplicationController
   private
 
   def filter(list)
-    if no_params_set? then
+    if no_params_set?
       list
     else
       result = []
       vm_filter.keys.each do |key|
-        result += list.select {|object| vm_filter[key].call(object)} if params[key].present?
+        result += list.select { |object| vm_filter[key].call(object) } if params[key].present?
       end
       result
     end
@@ -48,7 +47,6 @@ class VmsController < ApplicationController
     all_parameters = vm_filter.keys.map(&:to_s)
     actual_params = params.keys.map(&:to_s)
     if no_params_set?
-    then
       all_parameters
     else
       all_parameters - (all_parameters - actual_params)
@@ -62,6 +60,6 @@ class VmsController < ApplicationController
   end
 
   def vm_filter
-    {up_vms: proc {|vm| vm[:state]}, down_vms: proc {|vm| !vm[:state]}}
+    { up_vms: proc { |vm| vm[:state] }, down_vms: proc { |vm| !vm[:state] } }
   end
 end

--- a/app/views/errors/timeout.html.erb
+++ b/app/views/errors/timeout.html.erb
@@ -1,0 +1,5 @@
+<h1 class="display-1">Sorry!</h1>
+
+<p class="lead">
+  It seems you have lost connection to the HPI network :(
+</p>

--- a/app/views/servers/index.html.erb
+++ b/app/views/servers/index.html.erb
@@ -3,12 +3,6 @@
 </h1>
 <small class="text-muted">This is the overview page for all currently existing servers</small>
 
-<div class="container">
-  <% flash.each do |key, value| %>
-    <div class="alert alert-<%= key %>"><%= value %></div>
-  <% end %>
-</div>
-
 <%= form_tag({controller: "servers", action: "index"}, method: "get", class: "nifty_form") do %>
 <table class="table">
   <tbody>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -2,12 +2,6 @@
   Details for Host "<%= @host[:name] unless @host.nil?%>"
 </h1>
 
-<div class="container">
-  <% flash.each do |key, value| %>
-    <div class="alert alert-<%= key %>"><%= value %></div>
-  <% end %>
-</div>
-
 <table class="table">
     <tbody>
     <tr>

--- a/app/views/vms/index.html.erb
+++ b/app/views/vms/index.html.erb
@@ -1,19 +1,7 @@
-<% flash.each do |key, value| %>
-  <div class="alert alert-danger">
-    <%= content_tag :div, value %>
-  </div>
-<% end %>
-
 <h1>
   Virtual Machines
 </h1>
 <small class="text-muted">This is the overview page for all currently existing VMs</small>
-
-<div class="container">
-  <% flash.each do |key, value| %>
-    <div class="alert alert-<%= key %>"><%= value %></div>
-  <% end %>
-</div>
 
 <%= form_tag({controller: "vms", action: "index"}, method: "get", class: "nifty_form") do %>
 <table class="table">

--- a/app/views/vms/show.html.erb
+++ b/app/views/vms/show.html.erb
@@ -2,12 +2,6 @@
   Details for Virtual Machine "<%= @vm[:name] unless @vm.nil?%>"
 </h1>
 
-<div class="container">
-  <% flash.each do |key, value| %>
-    <div class="alert alert-<%= key %>"><%= value %></div>
-  <% end %>
-</div>
-
 <table class="table">
     <tbody>
     <tr>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,42 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2018_11_30_150921) do
 
-ActiveRecord::Schema.define(version: 20_181_130_150_921) do
-
-  create_table 'user_profiles', force: :cascade do |t|
-    t.integer 'user_id'
-    t.string 'first_name'
-    t.string 'last_name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_user_profiles_on_user_id'
+  create_table "requests", force: :cascade do |t|
+    t.string "name"
+    t.integer "cpu_cores"
+    t.integer "ram_mb"
+    t.integer "storage_mb"
+    t.string "operating_system"
+    t.text "comment"
+    t.text "rejection_information"
+    t.integer "status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'role'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "user_profiles", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "first_name"
+    t.string "last_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_profiles_on_user_id"
   end
 
-  create_table 'requests', force: :cascade do |t|
-    t.string 'name'
-    t.integer 'cpu_cores'
-    t.integer 'ram_mb'
-    t.integer 'storage_mb'
-    t.string 'operating_system'
-    t.string 'software'
-    t.text 'comment'
-    t.text 'rejection_information'
-    t.integer 'status', default: 0
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,41 +12,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_30_150921) do
-
-  create_table "requests", force: :cascade do |t|
-    t.string "name"
-    t.integer "cpu_cores"
-    t.integer "ram_mb"
-    t.integer "storage_mb"
-    t.string "operating_system"
-    t.text "comment"
-    t.text "rejection_information"
-    t.integer "status", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+ActiveRecord::Schema.define(version: 20_181_130_150_921) do
+  create_table 'requests', force: :cascade do |t|
+    t.string 'name'
+    t.integer 'cpu_cores'
+    t.integer 'ram_mb'
+    t.integer 'storage_mb'
+    t.string 'operating_system'
+    t.text 'comment'
+    t.text 'rejection_information'
+    t.integer 'status', default: 0
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "user_profiles", force: :cascade do |t|
-    t.integer "user_id"
-    t.string "first_name"
-    t.string "last_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_user_profiles_on_user_id"
+  create_table 'user_profiles', force: :cascade do |t|
+    t.integer 'user_id'
+    t.string 'first_name'
+    t.string 'last_name'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_user_profiles_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "role"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'role'
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
-
 end

--- a/spec/controllers/servers_controller_spec.rb
+++ b/spec/controllers/servers_controller_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe ServersController, type: :controller do
                                                            { name: 'anotherHost', connectionState: 'not connected' }]
 
       allow(VmApi).to receive(:instance).and_return double_api
-
-      double_flash = double
-      allow(double_flash).to receive(:discard)
-      allow_any_instance_of(ServersController).to receive(:flash).and_return(double_flash)
     end
 
     it 'returns http success' do
@@ -55,9 +51,9 @@ RSpec.describe ServersController, type: :controller do
       allow(VmApi).to receive(:instance).and_return double_api
     end
 
-    it 'returns http success' do
+    it 'returns http success or timeout' do
       get :show, params: { id: 1 }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:success).or have_http_status(408)
     end
 
     it 'renders show page' do

--- a/spec/controllers/servers_controller_spec.rb
+++ b/spec/controllers/servers_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ServersController, type: :controller do
                                                            { name: 'anotherHost', connectionState: 'not connected' }]
 
       allow(VmApi).to receive(:instance).and_return double_api
-      allow(double_api).to receive(:connected?).and_return true
 
       double_flash = double
       allow(double_flash).to receive(:discard)
@@ -53,7 +52,6 @@ RSpec.describe ServersController, type: :controller do
     before do
       double_api = double
       allow(double_api).to receive(:get_host).and_return(nil)
-      allow(double_api).to receive(:connected?).and_return true
       allow(VmApi).to receive(:instance).and_return double_api
     end
 

--- a/spec/controllers/vms_controller_spec.rb
+++ b/spec/controllers/vms_controller_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe VmsController, type: :controller do
     before do
       double_api = double
       allow(double_api).to receive(:get_vm).and_return(nil)
-      allow(double_api).to receive(:connected?).and_return true
       allow(VmApi).to receive(:new).and_return double_api
     end
 

--- a/spec/controllers/vms_controller_spec.rb
+++ b/spec/controllers/vms_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe VmsController, type: :controller do
                                                          { name: 'another VM', state: false, bootTime: 'now' }]
 
       allow(VmApi).to receive(:instance).and_return double_api
-      allow(double_api).to receive(:connected?).and_return true
     end
 
     it 'returns http success' do
@@ -49,7 +48,6 @@ RSpec.describe VmsController, type: :controller do
     before do
       double_api = double
       expect(double_api).to receive(:delete_vm)
-      allow(double_api).to receive(:connected?).and_return true
       allow(VmApi).to receive(:instance).and_return double_api
     end
 
@@ -64,7 +62,6 @@ RSpec.describe VmsController, type: :controller do
     before do
       double_api = double
       expect(double_api).to receive(:create_vm)
-      allow(double_api).to receive(:connected?).and_return true
       allow(VmApi).to receive(:instance).and_return double_api
     end
 

--- a/spec/controllers/vms_controller_spec.rb
+++ b/spec/controllers/vms_controller_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe VmsController, type: :controller do
 
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:connected?).and_return true
-
-      double_flash = double
-      allow(double_flash).to receive(:discard)
-      allow_any_instance_of(VmsController).to receive(:flash).and_return(double_flash)
     end
 
     it 'returns http success' do
@@ -95,13 +91,9 @@ RSpec.describe VmsController, type: :controller do
       allow(VmApi).to receive(:new).and_return double_api
     end
 
-    it 'returns http success' do
+    it 'returns http success or timeout' do
       get :show, params: { id: 1 }
-      expect(response).to have_http_status(:success)
-    end
-
-    it 'renders show page' do
-      expect(get(:show, params: { id: 1 })).to render_template('vms/show')
+      expect(response).to have_http_status(:success).or have_http_status(408)
     end
   end
 end


### PR DESCRIPTION
[//]: # (Lines starting with [//]: are considered to be comments. You do not have to delete those lines, they are not rendered upon release.)

**Related User Story**: #47 

**Description**

[//]: # (Describe the new feature and how you've implemented it)

 Connection errrors when accessing the portal from outside of the HPI are caught, a global error page is displayed. Furthermore,  the VM API is turned into a Singleton, so that accessing API methods does not create a new VMApi object. Stuff left over from the last branch for this issue is also removed.

**Steps to reproduce**

[//]: # (Please provide a description about how to test the new functionality. Don't forget to name user accounts required to test the feature.)

 This can be tested by accessing the portal from another network or with the WiFi turned off. 

**Annex**

[//]: # (Please provide screenshots or screencasts if applicable)

All timeout errors are caught globally in `app/controllers/application_controller.rb`. Should timeouts with different exceptions occur, they could be caught there as well.