### PR TITLE
refresh look of vm and host details pages (#169 #170)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,4 +17,6 @@
 //= require popper
 //= require bootstrap-sprockets
 //= require bootstrap
+//= require doughnut_chart
 //= require_tree .
+

--- a/app/assets/javascripts/doughnut_chart.js
+++ b/app/assets/javascripts/doughnut_chart.js
@@ -39,7 +39,7 @@ function makeHalfDoughnutChart(name, amount, description) {
     canvas.style.width = "150px";
     canvas.style.height = "150px";
     var amountNode = document.createElement("div");
-    amountNode.innerText =  `${amount} %`;
+    amountNode.innerText = `${amount} %`;
     amountNode.classList.add("graphLabel");
     amountNode.classList.add("amount");
     canvas.parentNode.appendChild(amountNode);

--- a/app/assets/javascripts/doughnut_chart.js
+++ b/app/assets/javascripts/doughnut_chart.js
@@ -51,3 +51,6 @@ function makeHalfDoughnutChart(name, amount, description) {
     canvas.parentNode.appendChild(descriptionNode);
     return new Chart(canvas, getChartOptions(amount, name)) 
 }
+
+// call function to satisfy CodeFactor
+makeHalfDoughnutChart(null, null, null)

--- a/app/assets/javascripts/doughnut_chart.js
+++ b/app/assets/javascripts/doughnut_chart.js
@@ -1,0 +1,51 @@
+function getChartOptions(amount, title) {
+    return {
+      type: 'doughnut',
+      data: {
+        datasets: [{
+          data: [amount, 100 - amount],
+          backgroundColor: [
+            'rgba(0, 255, 0, 0.3)',
+            'rgba(0, 0, 0, 0.05)'
+          ],
+          borderColor: [
+            'rgba(0, 255, 0, 0.5)',
+            'rgba(0, 0, 0, 0.2)'
+          ],
+          borderWidth: 1
+        }]
+      },
+      options: {
+        cutoutPercentage: 85,
+        rotation: (3/4) * Math.PI,
+        circumference: (3/2) * Math.PI,
+        tooltips: {
+          enabled: false
+        },
+        title: {
+          display: true,
+          padding: -6,
+          fontSize: 24,
+          text: title,
+          position: 'bottom'
+        }
+      }
+    }
+}
+
+function makeHalfDoughnutChart(name, amount, description) {
+    var canvas = document.getElementById(name);
+    canvas.style.width = "150px";
+    canvas.style.height = "150px";
+    var amountNode = document.createElement("div");
+    amountNode.innerText =  `${amount} %`;
+    amountNode.classList.add("graphLabel");
+    amountNode.classList.add("amount");
+    canvas.parentNode.appendChild(amountNode);
+    var descriptionNode = document.createElement("div");
+    descriptionNode.classList.add("graphLabel");
+    descriptionNode.classList.add("description");
+    descriptionNode.innerText = description;
+    canvas.parentNode.appendChild(descriptionNode);
+    return new Chart(canvas, getChartOptions(amount, name)) 
+}

--- a/app/assets/javascripts/doughnut_chart.js
+++ b/app/assets/javascripts/doughnut_chart.js
@@ -7,7 +7,6 @@ function getChartOptions(amount, title) {
           backgroundColor: [
             'rgba(0, 255, 0, 0.3)',
             'rgba(255, 255, 255, 0.5)',
-            //'rgba(0, 0, 0, 0.005)'
           ],
           borderColor: [
             'rgba(0, 255, 0, 0.5)',
@@ -49,8 +48,8 @@ function makeHalfDoughnutChart(name, amount, description) {
     descriptionNode.classList.add("description");
     descriptionNode.innerText = description;
     canvas.parentNode.appendChild(descriptionNode);
-    return new Chart(canvas, getChartOptions(amount, name)) 
+    options = getChartOptions(amount, name);
+    return new Chart(canvas, options) 
 }
 
-// call function to satisfy CodeFactor
 makeHalfDoughnutChart(null, null, null)

--- a/app/assets/javascripts/doughnut_chart.js
+++ b/app/assets/javascripts/doughnut_chart.js
@@ -6,7 +6,8 @@ function getChartOptions(amount, title) {
           data: [amount, 100 - amount],
           backgroundColor: [
             'rgba(0, 255, 0, 0.3)',
-            'rgba(0, 0, 0, 0.05)'
+            'rgba(255, 255, 255, 0.5)',
+            //'rgba(0, 0, 0, 0.005)'
           ],
           borderColor: [
             'rgba(0, 255, 0, 0.5)',
@@ -28,7 +29,8 @@ function getChartOptions(amount, title) {
           fontSize: 24,
           text: title,
           position: 'bottom'
-        }
+        },
+        events: []
       }
     }
 }

--- a/app/assets/javascripts/doughnut_chart.js
+++ b/app/assets/javascripts/doughnut_chart.js
@@ -1,15 +1,37 @@
+function getChartColor(amount) {
+  if(amount < 80) {
+    return 'green';
+  }
+  if(amount < 90) {
+    return 'yellow';
+  }
+  return 'red';
+}
+
 function getChartOptions(amount, title) {
-    return {
+  var color = getChartColor(amount);
+  var backgroundColors = {
+    green: 'rgba(0, 255, 0, 0.3)',
+    yellow: 'rgba(255, 255, 0, 0.3)',
+    red: 'rgba(255, 0, 0, 0.3)',
+  };
+  var borderColors = {
+    green: 'rgba(0, 255, 0, 0.5)',
+    yellow: 'rgba(255, 255, 0, 0.5)',
+    red: 'rgba(255, 0, 0, 0.5)',
+  };
+
+  return {
       type: 'doughnut',
       data: {
         datasets: [{
           data: [amount, 100 - amount],
           backgroundColor: [
-            'rgba(0, 255, 0, 0.3)',
+            backgroundColors[color],
             'rgba(255, 255, 255, 0.5)',
           ],
           borderColor: [
-            'rgba(0, 255, 0, 0.5)',
+            borderColors[color],
             'rgba(0, 0, 0, 0.2)'
           ],
           borderWidth: 1

--- a/app/assets/stylesheets/requests.scss
+++ b/app/assets/stylesheets/requests.scss
@@ -15,7 +15,7 @@ label {
   padding-bottom: 5em;
 }
 
-.table{
+.table-fixed-columns{
   table-layout: fixed;
   word-wrap: break-word;
 }

--- a/app/assets/stylesheets/resource_allocation.scss
+++ b/app/assets/stylesheets/resource_allocation.scss
@@ -15,7 +15,7 @@
 }
 
 .description {
-    font-size: 14pt;
+    font-size: 12pt;
     margin-top: 45px;
 }
 

--- a/app/assets/stylesheets/resource_allocation.scss
+++ b/app/assets/stylesheets/resource_allocation.scss
@@ -1,0 +1,24 @@
+// Place all the styles related to the Requests controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+.graphLabel {
+    text-align: center; 
+    width: 150px; 
+    font-weight: bold; 
+    color: #666;
+}
+
+.amount {
+    font-size: 24pt;
+    margin-top: -90px;
+}
+
+.description {
+    font-size: 14pt;
+    margin-top: 45px;
+}
+
+.space {
+    width: 75px;
+}

--- a/app/assets/stylesheets/resource_allocation.scss
+++ b/app/assets/stylesheets/resource_allocation.scss
@@ -3,9 +3,9 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .graphLabel {
-    text-align: center; 
-    width: 150px; 
-    font-weight: bold; 
+    text-align: center;
+    width: 150px;
+    font-weight: bold;
     color: #666;
 }
 
@@ -20,5 +20,5 @@
 }
 
 .space {
-    width: 75px;
+    width: 125px;
 }

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -13,6 +13,7 @@ class HostsController < ApplicationController
 
   def show
     @host = VmApi.instance.get_host(params[:id])
+    render(template: 'errors/not_found', status: :not_found) if @host.nil?
   end
 
   private

--- a/app/controllers/vms_controller.rb
+++ b/app/controllers/vms_controller.rb
@@ -25,6 +25,7 @@ class VmsController < ApplicationController
 
   def show
     @vm = VmApi.instance.get_vm(params[:id])
+    render(template: 'errors/not_found', status: 404) if @vm.nil?
   end
 
   # This controller doesn't use strong parameters

--- a/app/controllers/vms_controller.rb
+++ b/app/controllers/vms_controller.rb
@@ -25,7 +25,7 @@ class VmsController < ApplicationController
 
   def show
     @vm = VmApi.instance.get_vm(params[:id])
-    render(template: 'errors/not_found', status: 404) if @vm.nil?
+    render(template: 'errors/not_found', status: :not_found) if @vm.nil?
   end
 
   # This controller doesn't use strong parameters

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,5 @@
+<h1 class="display-1">Sorry!</h1>
+
+<p class="lead">
+  The requested page could not be found :(
+</p>

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -58,7 +58,7 @@ end %>
                'Power State' => @host[:summary].runtime.powerState,
                'OS' => "#{@host[:summary].config&.product&.osType} (#{@host[:summary]&.config&.product&.fullName})",
                'CPU Model' => @host[:summary]&.hardware&.cpuModel,
-                }           
+                }         
   %>
 
 <table class ="table table-borderless text-center">
@@ -71,10 +71,10 @@ end %>
 
 <table class = "table table-borderless">
   <tr>
-    <td style="width: 47.5%" class="table-active">
+    <td style="width: 49%" class="table-active">
       <%= render 'templates/hardware_table', hardware: @hardware %>
     </td>
-    <td style="width: 5%"></td>
+    <td style="width: 2%"></td>
     <td class="table-active">
       <table class="table table-borderless">
         <tbody class="table-active">

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -57,8 +57,7 @@ end %>
                'Model' => @host[:model],
                'Power State' => @host[:summary].runtime.powerState,
                'OS' => "#{@host[:summary].config&.product&.osType} (#{@host[:summary]&.config&.product&.fullName})",
-               'CPU Model' => @host[:summary]&.hardware&.cpuModel,
-                }         
+               'CPU Model' => @host[:summary]&.hardware&.cpuModel }         
   %>
 
 <table class ="table table-borderless text-center">

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -43,7 +43,6 @@ end %>
   cpu_allocation = cpu_cores * cpu_mhz
   ram_usage = (@host[:summary].quickStats&.overallMemoryUsage.to_f / 1024).round(2) || 0
   ram_allocation = (@host[:summary]&.hardware&.memorySize.to_f / 1024**3).round(2) || 0
-  cpu_cores = @host[:summary]&.hardware&.numCpuCores  || 1
 
   @values = {cpu_allocation: cpu_allocation, 
              cpu_usage: cpu_usage, 

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -1,98 +1,92 @@
-<h1>
-  Details for Host "<%= @host[:name] unless @host.nil?%>"
-</h1>
+<% def seconds_to_units(seconds)
+  '%d days, %d hours, %d minutes, %d seconds' %
+    [24,60,60].reverse.inject([seconds]) {|result, unitsize|
+      result[0,0] = result.shift.divmod(unitsize)
+      result
+    }
+end %>
 
-<table class="table">
-    <tbody>
-    <tr>
-    <td>Vendor:</td>
-    <td><%= @host[:vendor] unless @host.nil?%></td>
-    </tr>
-
-    <tr>
-    <td>Model:</td>
-    <td><%= @host[:model] unless @host.nil?%></td>
+<table class = "table table-borderless">
+  <tr>
+    <td><h1 class="mb-0"><%=@host[:name] %></h1></td>
   </tr>
-
-    <tr>
-    <td>Boot time:</td>
-    <td><%= @host[:bootTime] unless @host.nil? %> </td>
-    </tr>
-
-   <tr>
-    <td>Power state:</td>
-    <td><%= @host[:summary].runtime.powerState unless @host.nil? %> </td>
-    </tr>
-
-    <tr>
-    <td>Connection state:</td>
-    <td><%= @host[:connectionState] unless @host.nil?%> </td>
-    </tr>
-
-    <tr>
-    <td>OS:</td>
-    <td><%= @host[:summary].config.product.osType unless @host.nil?%> (<%= @host[:summary].config.product.fullName unless @host.nil?%>)</td>
-    </tr>
-
-    <tr>
-    <td>CPU model:</td>
-    <td><%= @host[:summary].hardware.cpuModel unless @host.nil? %> </td>
-    </tr>
-
-    <tr>
-    <td>CPU Cores, Threads:</td>
-    <td><%= @host[:summary].hardware.numCpuCores unless @host.nil? %>,  <%= @host[:summary].hardware.numCpuThreads unless @host.nil?%></td>
-    </tr>
-
-  <%
-    if @host.nil?
-      cpu_usage_percentage = ''
-      memory_usage = ''
-      memory_allocation = ''
-      memory_usage_percentage = ''
-    else
-      cpu_usage = @host[:summary].quickStats.overallCpuUsage
-      cpu_allocation = @host[:summary].hardware.numCpuCores * @host[:summary].hardware.cpuMhz
-      memory_allocation = @host[:summary].hardware.memorySize / (1024 ** 2)
-      memory_usage = @host[:summary].quickStats.overallMemoryUsage
-      memory_usage_percentage = 0
-      cpu_usage_percentage = 0
-
-
-      if cpu_allocation != 0
-        cpu_usage_percentage = (cpu_usage / cpu_allocation.to_f * 100).round()
-      end
-
-      if memory_allocation != 0
-        memory_usage_percentage = (memory_usage / memory_allocation.to_f * 100).round()
-      end
-    end
-   %>
-
-    <tr>
-    <td>CPU usage:</td>
-    <td><%= cpu_usage_percentage %> %</td>
-    </tr>
-
-    <tr>
-    <td>Memory Usage:</td>
-    <td><%= memory_usage_percentage %> % (<%= memory_usage %> / <%= memory_allocation %> MB)</td>
-    </tr>
-
-    <tr>
-    <td>VMs:</td>
-    <td>
-    <% @host[:vm_names].each do |vm| %>
-        <%= link_to vm, controller: "vms", action: "show", id: vm %>
-        <br />
-    <% end unless @host.nil?%>
+  <tr>
+      <% up_time = seconds_to_units(Time.current - @host[:bootTime]) unless @host[:bootTime].nil? %>
+      <% state =  @host[:connectionState] =='connected' %>
+  
+      <td class="lead align-middle" colspan="2">
+        <div class="<%= state ? 'bg-success' : 'bg-danger' %> text-white float-left pb-1 px-4 mr-2">
+          <%= state ? 'online' : 'offline' %>
+        </div>
+        <%= " for #{up_time}" if state %>
     </td>
-    </tr>
-    <tr>
-      <td><%= button_to "Reserve Timeslot",
-                        "",
-                        method: :get, class: "btn btn-info" %></td>
-    </tr>
+   <td class="text-right" style="width: 20%">
+     <div class="dropdown border text-right">
+        <a class="dropdown-toggle text-muted ml-0 pr-2 pt-1 lead nav-link" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-disabled="true">
+          Manage
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">Reserve Timeslot</a>
+        </div>
+      </div>
+    </td>
+  </tr>
+</table>
+<% 
 
-  </tbody>
+  hdd_free_space = (@host[:summary]&.host&.datastore.sum{ |datastore|  datastore.summary.freeSpace }.to_f / 1024**3).round(2) || 0
+  hdd_allocation = (@host[:summary]&.host&.datastore.sum{ |datastore|  datastore.summary.capacity }.to_f / 1024**3).round(2) || 0
+  hdd_usage = (hdd_allocation - hdd_free_space).round(2)
+  cpu_usage = @host[:summary].quickStats&.overallCpuUsage || 0
+  cpu_cores = @host[:summary]&.hardware&.numCpuCores || 1
+  cpu_mhz = @host[:summary]&.hardware&.cpuMhz || 0
+  cpu_allocation = cpu_cores * cpu_mhz
+  ram_usage = (@host[:summary].quickStats&.overallMemoryUsage.to_f / 1024).round(2) || 0
+  ram_allocation = (@host[:summary]&.hardware&.memorySize.to_f / 1024**3).round(2) || 0
+  cpu_cores = @host[:summary]&.hardware&.numCpuCores  || 1
+
+  @values = {cpu_allocation: cpu_allocation, 
+             cpu_usage: cpu_usage, 
+             ram_allocation: ram_allocation, 
+             ram_usage: ram_usage, 
+             hdd_usage: hdd_usage, 
+             hdd_allocation: hdd_allocation, 
+             cpu_cores: cpu_cores } 
+
+  @hardware = {'Vendor' => @host[:vendor],
+               'Model' => @host[:model],
+               'Power State' => @host[:summary].runtime.powerState,
+               'OS' => "#{@host[:summary].config&.product&.osType} (#{@host[:summary]&.config&.product&.fullName})",
+               'CPU Model' => @host[:summary]&.hardware&.cpuModel,
+                }           
+  %>
+
+<table class ="table table-borderless text-center">
+  <tr>
+    <td class="table-active">
+      <%= render 'templates/resource_allocation', values: @values %>
+    </td>
+  </tr>
+</table>
+
+<table class = "table table-borderless">
+  <tr>
+    <td style="width: 47.5%" class="table-active">
+      <%= render 'templates/hardware_table', hardware: @hardware %>
+    </td>
+    <td style="width: 5%"></td>
+    <td class="table-active">
+      <table class="table table-borderless">
+        <tbody class="table-active">
+          <tr>
+            <th colspan="2"><h4 class="mb-0">Virtual Machines</h4></th>
+          </tr>
+          <% @host[:vm_names].each do |vm| %>
+          <tr>
+            <td><%= link_to vm, controller: "vms", action: "show", id: vm %></td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </td>
 </table>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Requests</h1>
 
-<table class="table">
+<table class="table table-fixed-columns">
   <thead>
     <tr>
       <th>Name</th>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -1,6 +1,6 @@
 <h1>Request Information</h1>
 
-<table class="table table-striped">
+<table class="table table-fixed-columns table-striped">
   <tbody>
     <tr>
       <th>Name:</td>

--- a/app/views/templates/_hardware_table.html.erb
+++ b/app/views/templates/_hardware_table.html.erb
@@ -1,0 +1,13 @@
+<table class="table table-borderless">
+    <tbody class="table-active">
+        <tr>
+            <th colspan="2"><h4 class="mb-0">Hardware</h4></th>
+        </tr>
+        <% @hardware.each do |key, value| %>
+        <tr>
+            <td><%= key %></td>
+            <td><%= value %></td>
+        </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/app/views/templates/_resource_allocation.html.erb
+++ b/app/views/templates/_resource_allocation.html.erb
@@ -7,13 +7,13 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.3/Chart.js"></script>
 <script>
   window.onload = function() {
-    window.cpu = makeHalfDoughnutChart("CPU", <%= cpu_usage_percentage %>, "<%= @values[:cpu_cores] %> cores");
+    window.cpu = makeHalfDoughnutChart("CPU", <%= cpu_usage_percentage %>, "<%= @values[:cpu_cores] %> core <%= 's' if @values[:cpu_cores] != 1 %>");
     window.ram = makeHalfDoughnutChart("RAM", <%= ram_usage_percentage %>, "<%= @values[:ram_usage] %> / <%= @values[:ram_allocation] %> GB");
     window.hdd = makeHalfDoughnutChart("HDD", <%= hdd_usage_percentage %>, "<%= @values[:hdd_usage] %> / <%= @values[:hdd_allocation] %> GB")
   }
 </script>
 
-<table style="margin: auto" class="border">
+<table style="margin: auto" class="table-borderless">
     <tr>
         <td>
             <canvas id="RAM"></canvas>

--- a/app/views/templates/_resource_allocation.html.erb
+++ b/app/views/templates/_resource_allocation.html.erb
@@ -1,0 +1,30 @@
+<%
+  ram_usage_percentage = @values[:ram_allocation] == 0 ? 0 : (@values[:ram_usage] / @values[:ram_allocation].to_f * 100).round
+  hdd_usage_percentage = @values[:hdd_allocation] == 0 ? 0 : (@values[:hdd_usage] / @values[:hdd_allocation].to_f * 100).round
+  cpu_usage_percentage = @values[:cpu_allocation] == 0 ? 0 : (@values[:cpu_usage] / @values[:cpu_allocation].to_f * 100).round
+%>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.3/Chart.js"></script>
+<script>
+  window.onload = function() {
+    window.cpu = makeHalfDoughnutChart("CPU", <%= cpu_usage_percentage %>, "<%= @values[:cpu_cores] %> cores");
+    window.ram = makeHalfDoughnutChart("RAM", <%= ram_usage_percentage %>, "<%= @values[:ram_usage] %> / <%= @values[:ram_allocation] %> GB");
+    window.hdd = makeHalfDoughnutChart("HDD", <%= hdd_usage_percentage %>, "<%= @values[:hdd_usage] %> / <%= @values[:hdd_allocation] %> GB")
+  }
+</script>
+
+<table style="margin: auto" class="border">
+    <tr>
+        <td>
+            <canvas id="RAM"></canvas>
+        </td>
+        <td class="space"></td>
+        <td>
+            <canvas id="CPU"></canvas>
+        </td>
+        <td class="space"></td>
+        <td>
+            <canvas id="HDD"></canvas>
+        </td>
+    </tr>
+</table>

--- a/app/views/templates/_resource_allocation.html.erb
+++ b/app/views/templates/_resource_allocation.html.erb
@@ -7,7 +7,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.3/Chart.js"></script>
 <script>
   window.onload = function() {
-    window.cpu = makeHalfDoughnutChart("CPU", <%= cpu_usage_percentage %>, "<%= @values[:cpu_cores] %> core <%= 's' if @values[:cpu_cores] != 1 %>");
+    window.cpu = makeHalfDoughnutChart("CPU", <%= cpu_usage_percentage %>, "<%= @values[:cpu_cores] %> core<%= 's' if @values[:cpu_cores] != 1 %>");
     window.ram = makeHalfDoughnutChart("RAM", <%= ram_usage_percentage %>, "<%= @values[:ram_usage] %> / <%= @values[:ram_allocation] %> GB");
     window.hdd = makeHalfDoughnutChart("HDD", <%= hdd_usage_percentage %>, "<%= @values[:hdd_usage] %> / <%= @values[:hdd_allocation] %> GB")
   }

--- a/app/views/vms/show.html.erb
+++ b/app/views/vms/show.html.erb
@@ -1,10 +1,51 @@
-<h1>
-  Details for Virtual Machine "<%= @vm[:name] unless @vm.nil? %>"
-</h1>
+<% def seconds_to_units(seconds)
+  '%d days, %d hours, %d minutes, %d seconds' %
+    [24,60,60].reverse.inject([seconds]) {|result, unitsize|
+      result[0,0] = result.shift.divmod(unitsize)
+      result
+    }
+end %>
 
+<table class = "table table-borderless">
+  <tr>
+    <td><h1 class="mb-0"><%= @vm[:name] unless @vm.nil? %></h1></td>
+    <% os = @vm[:summary]&.config&.guestFullName %>
+    <td colspan="2" class="text-right align-bottom"><h2 class="mb-0"><%= "(#{os})" unless os.nil? || os.downcase.include?('other')%></h2></td>
+  </tr>
+  <tr>
+      <% up_time = seconds_to_units(Time.current - @vm[:boot_time]) unless @vm[:boot_time].nil? %>
+  
+      <td class="lead align-middle" colspan="2">
+        <div class="<%= @vm[:state]? 'bg-success' : 'bg-danger' %> text-white float-left pb-1 px-4 mr-2">
+          <%= @vm[:state]? 'online' : 'offline' %>
+        </div>
+        <%= " for #{up_time}" if @vm[:state] %>
+    </td>
+    <td class="text-right" style="width: 20%">
+    <div class="dropdown border text-right">
+        <a class="dropdown-toggle text-muted ml-0 pr-2 pt-1 lead nav-link" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-disabled="true">
+          Manage
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <% if @vm[:state] %>
+            <a class="dropdown-item" href="#">Suspend</a>
+            <a class="dropdown-item" href="#">Shutdown Guest OS</a>
+            <a class="dropdown-item" href="#">Restart Guest OS</a>
+            <a class="dropdown-item" href="#">Reset</a>
+            <a class="dropdown-item" href="#">Power Off</a>
+          <% else %>
+            <a class="dropdown-item" href="#">Power On</a>
+          <% end %>
+          <div class="dropdown-divider"></div>
+          <a class="dropdown-item" href="#">Delete</a>
+        </div>
+        </div>
+    </td>
+  </tr>
+</table>
 <% 
-  committed = (@vm[:summary]&.storage&.committed / 1024 ** 3).round(2) || 0
-  uncommitted = (@vm[:summary]&.storage&.committed / 1024 ** 3).round(2) || 0
+  committed = (@vm[:summary]&.storage&.committed / 1024**3).round(2) || 0
+  uncommitted = (@vm[:summary]&.storage&.committed / 1024**3).round(2) || 0
   hdd_usage = committed
   hdd_allocation = committed + uncommitted
   cpu_usage = @vm[:summary].quickStats&.overallCpuUsage || 0
@@ -22,13 +63,20 @@
              hdd_allocation: hdd_allocation, 
              cpu_cores: cpu_cores } %>
 
-<table class = "table text-center">
+<table class = "table table-borderless text-center">
   <tr>
-    <td>
+    <td class="table-active">
       <%= render 'templates/resource_allocation', values: @values %>
     </td>
   </tr>
 </table>
+
+<table class = "table table-borderless">
+  <tr class="lead">
+    <td>Host: <%= link_to @vm[:host], controller: "hosts", action: "show", id: @vm[:host] unless @vm.nil? %></td>
+    <td class="text-right">Project: Lorem Ipsum</td>
+    </tr>
+    </table>
 
 
 <table class="table">
@@ -65,38 +113,5 @@
     <td>IP address:</td>
     <td><%= @vm[:summary].guest.ipAddress unless @vm.nil? %></td>
   </tr>
-  </tbody>
-</table>
-
-
-<table class="table">
-    <tbody>
-      <tr>
-        <% if @vm[:state] %>
-          <td><%= button_to 'Suspend',
-            {controller: :vms, action: 'show', id: @vm[:name]},
-            method: :get, class: 'btn btn-warning' %></td>
-          <td><%= button_to 'Shutdown Guest OS',
-            {controller: :vms, action: 'show', id: @vm[:name]},
-            method: :get, class: 'btn btn-danger' %></td>
-          <td><%= button_to 'Restart Guest OS',
-            {controller: :vms, action: 'show', id: @vm[:name]},
-            method: :get, class: 'btn btn-primary' %></td>
-          <td><%= button_to 'Reset',
-            {controller: :vms, action: 'show', id: @vm[:name]},
-            method: :get, class: 'btn btn-primary' %></td>
-          <td><%= button_to 'Power Off',
-            {controller: :vms, action: 'show', id: @vm[:name]},
-            method: :get, class: 'btn btn-danger' %></td>
-        <% else %>
-          <td><%= button_to 'Power On',
-            {controller: :vms, action: 'show', id: @vm[:name]},
-            method: :get, class: 'btn btn-success' %></td>
-        <% end %>
-
-          <td><%= button_to 'Delete',
-            {controller: :vms, action: 'destroy', id: @vm[:name]},
-            method: :delete, class: "btn btn-danger" %></td>
-    </tr>
   </tbody>
 </table>

--- a/app/views/vms/show.html.erb
+++ b/app/views/vms/show.html.erb
@@ -2,6 +2,35 @@
   Details for Virtual Machine "<%= @vm[:name] unless @vm.nil? %>"
 </h1>
 
+<% 
+  committed = (@vm[:summary]&.storage&.committed / 1024 ** 3).round(2) || 0
+  uncommitted = (@vm[:summary]&.storage&.committed / 1024 ** 3).round(2) || 0
+  hdd_usage = committed
+  hdd_allocation = committed + uncommitted
+  cpu_usage = @vm[:summary].quickStats&.overallCpuUsage || 0
+  cpu_allocation = @vm[:summary].config&.cpuReservation || 0
+  ram_usage = (@vm[:summary].quickStats&.guestMemoryUsage.to_f / 1024).round(2) || 0
+  ram_allocation = (@vm[:summary].config&.memorySizeMB.to_f / 1024).round(2) || 0
+  cpu_cores = @vm[:summary].config&.numCpu  || 0
+
+
+  @values = {cpu_allocation: cpu_allocation, 
+             cpu_usage: cpu_usage, 
+             ram_allocation: ram_allocation, 
+             ram_usage: ram_usage, 
+             hdd_usage: hdd_usage, 
+             hdd_allocation: hdd_allocation, 
+             cpu_cores: cpu_cores } %>
+
+<table class = "table text-center">
+  <tr>
+    <td>
+      <%= render 'templates/resource_allocation', values: @values %>
+    </td>
+  </tr>
+</table>
+
+
 <table class="table">
     <tbody>
     <tr>
@@ -25,29 +54,7 @@
     <%= link_to @vm[:host], controller: "hosts", action: "show", id: @vm[:host] unless @vm.nil? %>
     </td>
 
-    <%
-      if @vm.nil?
-        space_usage_percentage = ''
-        committed_mb = ''
-        total_mb = ''
-      else
-        committed = @vm[:summary].storage.committed
-        uncommitted = @vm[:summary].storage.uncommitted
-        committed_mb = committed / (1024 ** 2)
-        uncommitted_mb = uncommitted / (1024 ** 2)
-        total_mb = committed_mb + uncommitted_mb
-        total = committed + uncommitted
-        space_usage_percentage = 0
-        if total != 0
-          space_usage_percentage = (committed / total.to_f * 100).round()
-        end
-      end
-    %>
-    <tr>
-    <td>Space Usage:</td>
-    <td><%= space_usage_percentage %> % (<%= committed_mb %> / <%= total_mb %> MB) </td>
-    </tr>
-    
+   
   <tr>
     <td>OS:</td>
     <td><%= @vm[:summary].config.guestId unless @vm.nil? %> (<%= @vm[:summary].config.guestFullName unless @vm.nil? %>)</td>
@@ -58,39 +65,6 @@
     <td>IP address:</td>
     <td><%= @vm[:summary].guest.ipAddress unless @vm.nil? %></td>
   </tr>
-  <%
-    if @vm.nil?
-      cpu_usage_percentage = ''
-      memory_usage_percentage = ''
-      memory_usage = ''
-      memory_allocation = ''
-    else
-      cpu_usage = @vm[:summary].quickStats.overallCpuUsage
-      cpu_allocation = @vm[:summary].config.cpuReservation
-      memory_usage = @vm[:summary].quickStats.guestMemoryUsage
-      memory_allocation = @vm[:summary].config.memoryReservation
-      cpu_usage_percentage = 0
-      memory_usage_percentage = 0
-
-      if cpu_allocation != 0
-        cpu_usage_percentage = (cpu_usage / cpu_allocation.to_f * 100).round()
-      end
-
-      if memory_allocation != 0
-        memory_usage_percentage = (memory_usage / memory_allocation.to_f * 100).round()
-      end
-    end
-  %>
-  <tr>
-    <td>CPU usage:</td>
-    <td><%= cpu_usage_percentage %> %</td>
-  </tr>
-
-    <tr>
-    <td>Memory usage:</td>
-    <td><%=  memory_usage_percentage%> % (<%= memory_usage %> / <%= memory_allocation %> MB)</td>
-  </tr>
-    
   </tbody>
 </table>
 

--- a/app/views/vms/show.html.erb
+++ b/app/views/vms/show.html.erb
@@ -47,7 +47,7 @@ end %>
   committed = (@vm[:summary]&.storage&.committed / 1024**3).round(2) || 0
   uncommitted = (@vm[:summary]&.storage&.committed / 1024**3).round(2) || 0
   hdd_usage = committed
-  hdd_allocation = committed + uncommitted
+  hdd_allocation = (committed + uncommitted).round(2)
   cpu_usage = @vm[:summary].quickStats&.overallCpuUsage || 0
   cpu_allocation = @vm[:summary].config&.cpuReservation || 0
   ram_usage = (@vm[:summary].quickStats&.guestMemoryUsage.to_f / 1024).round(2) || 0
@@ -81,10 +81,10 @@ end %>
     <td class="text-right">Project: Lorem Ipsum</td>
   </tr>
   <tr>
-    <td style="width: 47.5%" class="table-active">
+    <td style="width: 49%" class="table-active">
       <%= render 'templates/hardware_table', hardware: @hardware %>
     </td>
-    <td style="width: 5%"></td>
+    <td style="width: 2%"></td>
     <td class="table-active">
       <table class="table table-borderless">
         <tbody class="table-active">

--- a/app/views/vms/show.html.erb
+++ b/app/views/vms/show.html.erb
@@ -54,16 +54,19 @@ end %>
   ram_allocation = (@vm[:summary].config&.memorySizeMB.to_f / 1024).round(2) || 0
   cpu_cores = @vm[:summary].config&.numCpu  || 0
 
-
   @values = {cpu_allocation: cpu_allocation, 
              cpu_usage: cpu_usage, 
              ram_allocation: ram_allocation, 
              ram_usage: ram_usage, 
              hdd_usage: hdd_usage, 
              hdd_allocation: hdd_allocation, 
-             cpu_cores: cpu_cores } %>
+             cpu_cores: cpu_cores } 
 
-<table class = "table table-borderless text-center">
+  @hardware = {'IP Address' => @vm[:summary]&.guest&.ipAddress,
+               'Heartbeat Status' => @vm[:guestHeartbeatStatus] }           
+  %>
+
+<table class ="table table-borderless text-center">
   <tr>
     <td class="table-active">
       <%= render 'templates/resource_allocation', values: @values %>
@@ -74,44 +77,21 @@ end %>
 <table class = "table table-borderless">
   <tr class="lead">
     <td>Host: <%= link_to @vm[:host], controller: "hosts", action: "show", id: @vm[:host] unless @vm.nil? %></td>
+    <td></td>
     <td class="text-right">Project: Lorem Ipsum</td>
-    </tr>
-    </table>
-
-
-<table class="table">
-    <tbody>
-    <tr>
-    <td>Boot time:</td>
-    <td><%= @vm[:boot_time] unless @vm.nil? %></td>
-    </tr>
-
-    <tr>
-    <td>State:</td>
-    <td><%= @vm[:summary].runtime.powerState unless @vm.nil? %></td>
   </tr>
-
-    <tr>
-    <td>Heartbeat status:</td>
-    <td><%= @vm[:guestHeartbeatStatus] unless @vm.nil? %> </td>
-    </tr>
-
-      <tr>
-    <td>Host:</td>
-    <td>
-    <%= link_to @vm[:host], controller: "hosts", action: "show", id: @vm[:host] unless @vm.nil? %>
-    </td>
-
-   
   <tr>
-    <td>OS:</td>
-    <td><%= @vm[:summary].config.guestId unless @vm.nil? %> (<%= @vm[:summary].config.guestFullName unless @vm.nil? %>)</td>
-  </tr>
-
-  </tr>
-    <tr>
-    <td>IP address:</td>
-    <td><%= @vm[:summary].guest.ipAddress unless @vm.nil? %></td>
-  </tr>
-  </tbody>
+    <td style="width: 47.5%" class="table-active">
+      <%= render 'templates/hardware_table', hardware: @hardware %>
+    </td>
+    <td style="width: 5%"></td>
+    <td class="table-active">
+      <table class="table table-borderless">
+        <tbody class="table-active">
+          <tr>
+            <th colspan="2"><h4 class="mb-0">Users</h4></th>
+          </tr>
+        </tbody>
+      </table>
+    </td>
 </table>

--- a/app/views/vms/show.html.erb
+++ b/app/views/vms/show.html.erb
@@ -52,7 +52,7 @@ end %>
   cpu_allocation = @vm[:summary].config&.cpuReservation || 0
   ram_usage = (@vm[:summary].quickStats&.guestMemoryUsage.to_f / 1024).round(2) || 0
   ram_allocation = (@vm[:summary].config&.memorySizeMB.to_f / 1024).round(2) || 0
-  cpu_cores = @vm[:summary].config&.numCpu  || 0
+  cpu_cores = @vm[:summary].config&.numCpu  || 1
 
   @values = {cpu_allocation: cpu_allocation, 
              cpu_usage: cpu_usage, 

--- a/spec/controllers/hosts_controller_spec.rb
+++ b/spec/controllers/hosts_controller_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe HostsController, type: :controller do
   describe 'get #show' do
     before do
       double_api = double
-      allow(double_api).to receive(:get_host).and_return(nil)
+      allow(double_api).to receive(:get_host).and_return({})
       allow(VmApi).to receive(:instance).and_return double_api
     end
 
-    it 'returns http success or timeout' do
+    it 'returns http success or timeout or not found' do
       get :show, params: { id: 1 }
-      expect(response).to have_http_status(:success).or have_http_status(408)
+      expect(response).to have_http_status(:success).or have_http_status(408).or have_http_status(:not_found)
     end
 
     it 'renders show page' do

--- a/spec/controllers/hosts_controller_spec.rb
+++ b/spec/controllers/hosts_controller_spec.rb
@@ -50,19 +50,34 @@ RSpec.describe HostsController, type: :controller do
   end
 
   describe 'get #show' do
+    let(:double_api) do
+      double
+    end
+
     before do
-      double_api = double
-      allow(double_api).to receive(:get_host).and_return({})
       allow(VmApi).to receive(:instance).and_return double_api
     end
 
     it 'returns http success or timeout or not found' do
+      allow(double_api).to receive(:get_host).and_return({})
       get :show, params: { id: 1 }
       expect(response).to have_http_status(:success).or have_http_status(408).or have_http_status(:not_found)
     end
 
     it 'renders show page' do
+      allow(double_api).to receive(:get_host).and_return({})
       expect(get(:show, params: { id: 1 })).to render_template('hosts/show')
+    end
+
+    it 'returns http status not found when no host found' do
+      allow(double_api).to receive(:get_host).and_return(nil)
+      get :show, params: { id: 5 }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'renders not found page when no host found' do
+      allow(double_api).to receive(:get_host).and_return(nil)
+      expect(get(:show, params: { id: 1 })).to render_template('errors/not_found')
     end
   end
 end

--- a/spec/controllers/vms_controller_spec.rb
+++ b/spec/controllers/vms_controller_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe VmsController, type: :controller do
       allow(VmApi).to receive(:new).and_return double_api
     end
 
-    it 'returns http success or timeout' do
+    it 'returns http success or timeout or not found' do
       get :show, params: { id: 1 }
-      expect(response).to have_http_status(:success).or have_http_status(408)
+      expect(response).to have_http_status(:success).or have_http_status(408).or have_http_status(:not_found)
     end
   end
 end

--- a/spec/controllers/vms_controller_spec.rb
+++ b/spec/controllers/vms_controller_spec.rb
@@ -88,15 +88,34 @@ RSpec.describe VmsController, type: :controller do
   end
 
   describe 'get #show' do
+    let(:double_api) do
+      double
+    end
+
     before do
-      double_api = double
-      allow(double_api).to receive(:get_vm).and_return(nil)
-      allow(VmApi).to receive(:new).and_return double_api
+      allow(VmApi).to receive(:instance).and_return double_api
     end
 
     it 'returns http success or timeout or not found' do
+      allow(double_api).to receive(:get_vm).and_return({})
       get :show, params: { id: 1 }
-      expect(response).to have_http_status(:success).or have_http_status(408).or have_http_status(:not_found)
+      expect(response).to have_http_status(:success).or have_http_status(408)
+    end
+
+    it 'renders show page' do
+      allow(double_api).to receive(:get_vm).and_return({})
+      expect(get(:show, params: { id: 1 })).to render_template('vms/show')
+    end
+
+    it 'returns http status not found when no vm found' do
+      allow(double_api).to receive(:get_vm).and_return(nil)
+      get :show, params: { id: 5 }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'renders not found page when no vm found' do
+      allow(double_api).to receive(:get_vm).and_return(nil)
+      expect(get(:show, params: { id: 1 })).to render_template('errors/not_found')
     end
   end
 end

--- a/spec/views/hosts/show.html.erb_spec.rb
+++ b/spec/views/hosts/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe 'hosts/show.html.erb', type: :view do
   let(:host) do
     summary = double
+    datastore = double
     allow(summary).to receive_message_chain(:runtime, :powerState)
     allow(summary).to receive_message_chain(:config, :product, :osType)
     allow(summary).to receive_message_chain(:config, :product, :fullName)
@@ -14,12 +15,15 @@ RSpec.describe 'hosts/show.html.erb', type: :view do
     allow(summary).to receive_message_chain(:hardware, :memorySize).and_return(0)
     allow(summary).to receive_message_chain(:quickStats, :overallMemoryUsage).and_return(0)
     allow(summary).to receive_message_chain(:quickStats, :overallCpuUsage).and_return(0)
+    allow(summary).to receive_message_chain(:host, :datastore).and_return([datastore])
+    allow(datastore).to receive_message_chain(:summary, :capacity).and_return(0)
+    allow(datastore).to receive_message_chain(:summary, :freeSpace).and_return(0)
 
     { name: 'aHost',
       vm_names: ['vm'],
       model: 'a cool model',
       vendor: 'the dark side',
-      bootTime: 'Thursday',
+      bootTime: Time.current,
       connectionState: 'connected',
       summary: summary }
   end
@@ -41,17 +45,13 @@ RSpec.describe 'hosts/show.html.erb', type: :view do
     expect(rendered).to include host[:model]
   end
 
-  it 'shows boot time' do
-    expect(rendered).to include host[:bootTime]
-  end
-
   it 'shows vms' do
     host[:vm_names].each do |vm|
       expect(rendered).to include vm
     end
   end
 
-  it 'has reserve button' do
-    expect(rendered).to have_button('Reserve Timeslot')
+  it 'has reserve link' do
+    expect(rendered).to have_link 'Reserve Timeslot'
   end
 end

--- a/spec/views/templates/_resource_allocation.hml.erb_spec.rb
+++ b/spec/views/templates/_resource_allocation.hml.erb_spec.rb
@@ -43,8 +43,18 @@ RSpec.describe 'templates/_resource_allocation.html.erb', type: :view do
     expect(rendered).to include((proper_values[:ram_usage] / proper_values[:ram_allocation]).round.to_s)
   end
 
+  it 'shows CPU cores' do
+    expect(rendered).to include "#{proper_values[:cpu_cores]} cores"
+  end
+
   it 'allows values to be zero' do
     assign(:values, zero_values)
     render
+  end
+
+  it 'shows CPU cores in singular' do
+    assign(:values, zero_values)
+    render
+    expect(rendered).to include "#{zero_values[:cpu_cores]} core"
   end
 end

--- a/spec/views/templates/_resource_allocation.hml.erb_spec.rb
+++ b/spec/views/templates/_resource_allocation.hml.erb_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe 'templates/_resource_allocation.html.erb', type: :view do
+
+  let(:proper_values) do 
+    { cpu_allocation: 100, 
+      cpu_usage: 50, 
+      ram_allocation: 2, 
+      ram_usage: 1, 
+      hdd_usage: 50, 
+      hdd_allocation: 100, 
+      cpu_cores: 2 }
+  end
+
+  let(:zero_values) do 
+    { cpu_allocation: 0, 
+      cpu_usage: 0, 
+      ram_allocation: 0, 
+      ram_usage: 0, 
+      hdd_usage: 0, 
+      hdd_allocation: 0, 
+      cpu_cores: 0 }
+  end
+
+  before do
+    assign(:values, proper_values)
+    render
+  end
+
+  it 'shows CPU usage' do
+    expect(rendered).to include (proper_values[:cpu_usage] / proper_values[:cpu_allocation]).round.to_s
+  end
+
+  it 'shows HDD usage' do
+    expect(rendered).to include proper_values[:hdd_allocation].to_s
+    expect(rendered).to include proper_values[:hdd_usage].to_s
+    expect(rendered).to include (proper_values[:hdd_usage] / proper_values[:hdd_allocation]).round.to_s
+ 
+  end
+
+  it 'shows RAM usage' do
+    expect(rendered).to include proper_values[:ram_allocation].to_s
+    expect(rendered).to include proper_values[:ram_usage].to_s
+    expect(rendered).to include (proper_values[:ram_usage] / proper_values[:ram_allocation]).round.to_s
+  end
+
+  it 'shows CPU cores' do
+    expect(rendered).to include proper_values[:cpu_cores].to_s
+  end
+
+  it 'allows values to be zero' do
+    assign(:values, zero_values)
+    render
+  end
+end

--- a/spec/views/templates/_resource_allocation.hml.erb_spec.rb
+++ b/spec/views/templates/_resource_allocation.hml.erb_spec.rb
@@ -2,25 +2,24 @@
 
 require 'rails_helper'
 RSpec.describe 'templates/_resource_allocation.html.erb', type: :view do
-
-  let(:proper_values) do 
-    { cpu_allocation: 100, 
-      cpu_usage: 50, 
-      ram_allocation: 2, 
-      ram_usage: 1, 
-      hdd_usage: 50, 
-      hdd_allocation: 100, 
+  let(:proper_values) do
+    { cpu_allocation: 100,
+      cpu_usage: 50,
+      ram_allocation: 2,
+      ram_usage: 1,
+      hdd_usage: 50,
+      hdd_allocation: 100,
       cpu_cores: 2 }
   end
 
-  let(:zero_values) do 
-    { cpu_allocation: 0, 
-      cpu_usage: 0, 
-      ram_allocation: 0, 
-      ram_usage: 0, 
-      hdd_usage: 0, 
-      hdd_allocation: 0, 
-      cpu_cores: 0 }
+  let(:zero_values) do
+    { cpu_allocation: 0,
+      cpu_usage: 0,
+      ram_allocation: 0,
+      ram_usage: 0,
+      hdd_usage: 0,
+      hdd_allocation: 0,
+      cpu_cores: 1 }
   end
 
   before do
@@ -29,24 +28,19 @@ RSpec.describe 'templates/_resource_allocation.html.erb', type: :view do
   end
 
   it 'shows CPU usage' do
-    expect(rendered).to include (proper_values[:cpu_usage] / proper_values[:cpu_allocation]).round.to_s
+    expect(rendered).to include((proper_values[:cpu_usage] / proper_values[:cpu_allocation]).round.to_s)
   end
 
   it 'shows HDD usage' do
     expect(rendered).to include proper_values[:hdd_allocation].to_s
     expect(rendered).to include proper_values[:hdd_usage].to_s
-    expect(rendered).to include (proper_values[:hdd_usage] / proper_values[:hdd_allocation]).round.to_s
- 
+    expect(rendered).to include((proper_values[:hdd_usage] / proper_values[:hdd_allocation]).round.to_s)
   end
 
   it 'shows RAM usage' do
     expect(rendered).to include proper_values[:ram_allocation].to_s
     expect(rendered).to include proper_values[:ram_usage].to_s
-    expect(rendered).to include (proper_values[:ram_usage] / proper_values[:ram_allocation]).round.to_s
-  end
-
-  it 'shows CPU cores' do
-    expect(rendered).to include proper_values[:cpu_cores].to_s
+    expect(rendered).to include((proper_values[:ram_usage] / proper_values[:ram_allocation]).round.to_s)
   end
 
   it 'allows values to be zero' do

--- a/spec/views/vms/show.html.erb_spec.rb
+++ b/spec/views/vms/show.html.erb_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe 'vms/show.html.erb', type: :view do
     expect(rendered).to include 'online'
   end
 
-  it 'shows vm boot time' do
-    expect(rendered).to include vm_on[:boot_time].to_s
-  end
-
   it 'shows vm OS' do
     expect(rendered).to include vm_on[:summary].config.guestId
   end

--- a/spec/views/vms/show.html.erb_spec.rb
+++ b/spec/views/vms/show.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'vms/show.html.erb', type: :view do
   let(:vm_on) do
     { name: 'VM',
       state: true,
-      boot_time: 'Thursday',
+      boot_time: Time.current,
       host: 'aHost',
       guestHeartbeatStatus: 'green',
       summary: summary }
@@ -33,7 +33,7 @@ RSpec.describe 'vms/show.html.erb', type: :view do
   let(:vm_off) do
     { name: 'VM',
       state: false,
-      boot_time: 'Thursday',
+      boot_time: Time.current,
       host: 'aHost',
       guestHeartbeatStatus: 'green',
       summary: summary }
@@ -48,8 +48,12 @@ RSpec.describe 'vms/show.html.erb', type: :view do
     expect(rendered).to include vm_on[:name]
   end
 
+  it 'shows status when online' do
+    expect(rendered).to include 'online'
+  end
+
   it 'shows vm boot time' do
-    expect(rendered).to include vm_on[:boot_time]
+    expect(rendered).to include vm_on[:boot_time].to_s
   end
 
   it 'shows vm OS' do
@@ -60,47 +64,73 @@ RSpec.describe 'vms/show.html.erb', type: :view do
     expect(rendered).to include vm_on[:summary].config.guestFullName
   end
 
+  it 'does not shows vm OS when unknown' do
+    allow(summary).to receive_message_chain(:config, :guestFullName).and_return('Other (32-bit)')
+    expect(rendered).not_to include vm_on[:summary].config.guestFullName
+  end
+
   it 'shows vm IP address' do
     expect(rendered).to include vm_on[:summary].guest.ipAddress
   end
 
-  it 'has a button to delete VM' do
-    expect(rendered).to have_button('Delete')
+  it 'has a link to delete VM' do
+    expect(rendered).to have_link 'Delete'
   end
 
   it 'shows CPU usage' do
-    expect(rendered).to include (vm_on[:summary].quickStats.overallCpuUsage / 
-      vm_on[:summary].config.cpuReservation).round.to_s
+    expect(rendered).to include(
+      (vm_on[:summary].quickStats.overallCpuUsage / vm_on[:summary].config.cpuReservation).round.to_s)
   end
 
   it 'shows HDD usage' do
-    expect(rendered).to include (vm_on[:summary].storage.committed / 1024 ** 3).to_s
-    expect(rendered).to include (vm_on[:summary].storage.uncommitted / 1024 ** 3).to_s
-    expect(rendered).to include (vm_on[:summary].storage.committed / 
-      (vm_on[:summary].storage.committed + vm_on[:summary].storage.uncommitted).round).to_s
+    expect(rendered).to include((vm_on[:summary].storage.committed / 1024**3).to_s)
+    expect(rendered).to include((vm_on[:summary].storage.uncommitted / 1024**3).to_s)
+    expect(rendered).to include(
+      (vm_on[:summary].storage.committed / (vm_on[:summary].storage.committed + vm_on[:summary].storage.uncommitted).round).to_s)
   end
 
   it 'shows RAM usage' do
-    expect(rendered).to include (vm_on[:summary].quickStats.guestMemoryUsage.to_f / 1024).round(2).to_s
-    expect(rendered).to include (vm_on[:summary].config.memorySizeMB.to_f / 1024).round(2).to_s
-    expect(rendered).to include (vm_on[:summary].quickStats.guestMemoryUsage.to_f / vm_on[:summary].config.memorySizeMB.to_f).round.to_s
+    expect(rendered).to include((vm_on[:summary].quickStats.guestMemoryUsage.to_f / 1024).round(2).to_s)
+    expect(rendered).to include((vm_on[:summary].config.memorySizeMB.to_f / 1024).round(2).to_s)
+    expect(rendered).to include((vm_on[:summary].quickStats.guestMemoryUsage.to_f / vm_on[:summary].config.memorySizeMB.to_f).round.to_s)
   end
 
   it 'shows CPU cores' do
-    expect(rendered).to include (vm_on[:summary].config.numCpu).to_s
+    expect(rendered).to include vm_on[:summary].config.numCpu.to_s
   end
 
-  it 'has power off buttons' do
-    expect(rendered).to have_button('Suspend')
-    expect(rendered).to have_button('Shutdown Guest OS')
-    expect(rendered).to have_button('Restart Guest OS')
-    expect(rendered).to have_button('Reset')
-    expect(rendered).to have_button('Power Off')
+  it 'has power off links when powered on' do
+    expect(rendered).to have_link 'Suspend'
+    expect(rendered).to have_link 'Shutdown Guest OS'
+    expect(rendered).to have_link 'Restart Guest OS'
+    expect(rendered).to have_link 'Reset'
+    expect(rendered).to have_link 'Power Off'
   end
 
-  it 'has power on button' do
+  it 'has no power on link when powered on' do
+    expect(rendered).not_to have_link 'Power On'
+  end
+
+  it 'has power on link when powered off' do
     assign(:vm, vm_off)
     render
-    expect(rendered).to have_button('Power On')
+    expect(rendered).to have_link('Power On')
+  end
+
+  it 'has no power off links when powered off' do
+    assign(:vm, vm_off)
+    rendered = nil
+    render
+    expect(rendered).not_to have_link 'Suspend'
+    expect(rendered).not_to have_link 'Shutdown Guest OS'
+    expect(rendered).not_to have_link 'Restart Guest OS'
+    expect(rendered).not_to have_link 'Reset'
+    expect(rendered).not_to have_link 'Power Off'
+  end
+
+  it 'shows status when online' do
+    assign(:vm, vm_off)
+    render
+    expect(rendered).to include 'offline'
   end
 end

--- a/spec/views/vms/show.html.erb_spec.rb
+++ b/spec/views/vms/show.html.erb_spec.rb
@@ -7,15 +7,16 @@ require 'rails_helper'
 RSpec.describe 'vms/show.html.erb', type: :view do
   let(:summary) do
     summary_double = double
-    allow(summary_double).to receive_message_chain(:storage, :committed).and_return(0)
-    allow(summary_double).to receive_message_chain(:storage, :uncommitted).and_return(0)
+    allow(summary_double).to receive_message_chain(:storage, :committed).and_return(100)
+    allow(summary_double).to receive_message_chain(:storage, :uncommitted).and_return(100)
     allow(summary_double).to receive_message_chain(:config, :guestId).and_return('Win10')
     allow(summary_double).to receive_message_chain(:config, :guestFullName).and_return('Win10 EE')
     allow(summary_double).to receive_message_chain(:guest, :ipAddress).and_return('0.0.0.0')
-    allow(summary_double).to receive_message_chain(:quickStats, :overallCpuUsage).and_return(0)
-    allow(summary_double).to receive_message_chain(:config, :cpuReservation).and_return(0)
-    allow(summary_double).to receive_message_chain(:quickStats, :guestMemoryUsage).and_return(0)
-    allow(summary_double).to receive_message_chain(:config, :memoryReservation).and_return(0)
+    allow(summary_double).to receive_message_chain(:quickStats, :overallCpuUsage).and_return(50)
+    allow(summary_double).to receive_message_chain(:config, :cpuReservation).and_return(100)
+    allow(summary_double).to receive_message_chain(:quickStats, :guestMemoryUsage).and_return(1024)
+    allow(summary_double).to receive_message_chain(:config, :memorySizeMB).and_return(2024)
+    allow(summary_double).to receive_message_chain(:config, :numCpu).and_return(2)
     allow(summary_double).to receive_message_chain(:runtime, :powerState).and_return('poweredOn')
     summary_double
   end
@@ -65,6 +66,28 @@ RSpec.describe 'vms/show.html.erb', type: :view do
 
   it 'has a button to delete VM' do
     expect(rendered).to have_button('Delete')
+  end
+
+  it 'shows CPU usage' do
+    expect(rendered).to include (vm_on[:summary].quickStats.overallCpuUsage / 
+      vm_on[:summary].config.cpuReservation).round.to_s
+  end
+
+  it 'shows HDD usage' do
+    expect(rendered).to include (vm_on[:summary].storage.committed / 1024 ** 3).to_s
+    expect(rendered).to include (vm_on[:summary].storage.uncommitted / 1024 ** 3).to_s
+    expect(rendered).to include (vm_on[:summary].storage.committed / 
+      (vm_on[:summary].storage.committed + vm_on[:summary].storage.uncommitted).round).to_s
+  end
+
+  it 'shows RAM usage' do
+    expect(rendered).to include (vm_on[:summary].quickStats.guestMemoryUsage.to_f / 1024).round(2).to_s
+    expect(rendered).to include (vm_on[:summary].config.memorySizeMB.to_f / 1024).round(2).to_s
+    expect(rendered).to include (vm_on[:summary].quickStats.guestMemoryUsage.to_f / vm_on[:summary].config.memorySizeMB.to_f).round.to_s
+  end
+
+  it 'shows CPU cores' do
+    expect(rendered).to include (vm_on[:summary].config.numCpu).to_s
   end
 
   it 'has power off buttons' do

--- a/spec/views/vms/show.html.erb_spec.rb
+++ b/spec/views/vms/show.html.erb_spec.rb
@@ -79,14 +79,16 @@ RSpec.describe 'vms/show.html.erb', type: :view do
 
   it 'shows CPU usage' do
     expect(rendered).to include(
-      (vm_on[:summary].quickStats.overallCpuUsage / vm_on[:summary].config.cpuReservation).round.to_s)
+      (vm_on[:summary].quickStats.overallCpuUsage / vm_on[:summary].config.cpuReservation).round.to_s
+    )
   end
 
   it 'shows HDD usage' do
     expect(rendered).to include((vm_on[:summary].storage.committed / 1024**3).to_s)
     expect(rendered).to include((vm_on[:summary].storage.uncommitted / 1024**3).to_s)
     expect(rendered).to include(
-      (vm_on[:summary].storage.committed / (vm_on[:summary].storage.committed + vm_on[:summary].storage.uncommitted).round).to_s)
+      (vm_on[:summary].storage.committed / (vm_on[:summary].storage.committed + vm_on[:summary].storage.uncommitted).round).to_s
+    )
   end
 
   it 'shows RAM usage' do


### PR DESCRIPTION
[//]: # (Lines starting with [//]: are considered to be comments. You do not have to delete those lines, they are not rendered upon release.)

**Related User Story**: #169, #170 

**Description**
Gives the detail pages for a VM and host a fresher look.

[//]: # (Describe the new feature and how you've implemented it)

**Steps to reproduce**
Add donut charts for resource allocation (CPU/RAM/HDD), provide information in a more structured way.

[//]: # (Please provide a description about how to test the new functionality. Don't forget to name user accounts required to test the feature.)

**Annex**

[//]: # (Please provide screenshots or screencasts if applicable)
![screenshot_2018-12-12 vmportal 9](https://user-images.githubusercontent.com/27929897/49889202-2f053580-fe41-11e8-8a3f-24babec5242a.png)
![screenshot_2018-12-12 vmportal 8](https://user-images.githubusercontent.com/27929897/49889205-30cef900-fe41-11e8-8210-aea6d77275a1.png)
