### PR TITLE
146/login/Successful-login-logout-messages-green

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,11 @@ class ApplicationController < ActionController::Base
     vms_path
   end
 
+  # Overwriting the sign_out redirect path method
+  def after_sign_out_path_for(_resource)
+    root_path
+  end
+
   rescue_from Net::OpenTimeout, Errno::ENETUNREACH, Errno::EHOSTUNREACH, with: :error_render_method
 
   def error_render_method

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -20,7 +20,7 @@
       </li>
       <% if user_signed_in? %>
         <li>
-          <%= link_to('Logout', destroy_user_session_path, method: :delete, class: "nav-link text-danger") %>
+          <%= link_to('Logout', destroy_user_session_path, method: :delete, class: "nav-link text-success") %>
         </li>
       <% else %>
         <li>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -1,3 +1,5 @@
+<%= render('layouts/flash_message') %>
+
 <h1>Welcome to HART<br/>
 <small class="text-muted">Landing#index</small></h1>
 <p>Find me in app/views/landing/index.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   patch 'requests/request_accept_button', to: 'requests#request_accept_button', as: 'request_accept_button'
   resources :requests, path: '/vms/requests'
 
-  root to: redirect('/vms')
+  # root to: redirect('/vms')
 
   get '/servers/:id' => 'servers#show', constraints: { id: /.*/ }
 


### PR DESCRIPTION
add refactored and styled flash messages to landing vms and sign_in page, remove duplicate root \vms root is still landing#index, changed logout flash message from danger to success, added hook for different sign_out path. after logout there will be a green flash message "successfully logged out"