### PR TITLE
147/Rename all occurences of wimi to employee

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,8 @@ class ApplicationController < ActionController::Base
     render(template: 'errors/timeout', status: 408) && return
   end
 
-  def authenticate_wimi
-    redirect_to root_path, alert: I18n.t('authorization.unauthorized') unless current_user && (current_user.admin? || current_user.wimi?)
+  def authenticate_employee
+    redirect_to root_path, alert: I18n.t('authorization.unauthorized') unless current_user && (current_user.admin? || current_user.employee?)
   end
 
   def authenticate_admin

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,7 +3,7 @@
 class RequestsController < ApplicationController
   include OperatingSystemsHelper
   before_action :set_request, only: %i[show edit update destroy]
-  before_action :authenticate_wimi
+  before_action :authenticate_employee
 
   # GET /requests
   # GET /requests.json

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[hpi]
-   :trackable
+         :trackable
   enum role: %i[user employee admin]
 
   has_many :users_assigned_to_requests

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,7 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[hpi]
-         :trackable
+         :trackable, :omniauthable, omniauth_providers: %i[hpi]
   enum role: %i[user employee admin]
 
   has_many :users_assigned_to_requests

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[hpi]
-  :trackable
-  enum role: %i[user wimi admin]
+   :trackable
+  enum role: %i[user employee admin]
 
   has_many :users_assigned_to_requests
   has_many :requests, through: :users_assigned_to_requests

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -27,7 +27,7 @@ require 'rails_helper'
 
 RSpec.describe RequestsController, type: :controller do
   # Authenticate an user
-  login_wimi
+  login_employee
 
   # This should return the minimal set of attributes required to create a valid
   # Request. As you add validations to Request, be sure to

--- a/spec/features/requests/accept_reject_request_spec.rb
+++ b/spec/features/requests/accept_reject_request_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'accepting and rejecting requests', type: :feature do
   # Authenticate an user
   before do
-    sign_in FactoryBot.create :user, role: :wimi
+    sign_in FactoryBot.create :user, role: :employee
   end
 
   context 'when request status is pending' do

--- a/spec/features/requests/select_operating_system_spec.rb
+++ b/spec/features/requests/select_operating_system_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'operating_system selection for request', type: :feature do
   before do
-    sign_in FactoryBot.create :user, role: :wimi
+    sign_in FactoryBot.create :user, role: :employee
   end
 
   it 'has a selection of operating_systems' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,21 +11,21 @@ RSpec.describe User, type: :model do
   it 'can be a user' do
     user = FactoryBot.create(:user, role: :user)
     expect(user).to be_user
-    expect(user).not_to be_wimi
+    expect(user).not_to be_employee
     expect(user).not_to be_admin
   end
 
-  it 'can be a wimi' do
-    user = FactoryBot.create(:user, role: :wimi)
+  it 'can be a employee' do
+    user = FactoryBot.create(:user, role: :employee)
     expect(user).not_to be_user
-    expect(user).to be_wimi
+    expect(user).to be_employee
     expect(user).not_to be_admin
   end
 
   it 'can be an admin' do
     user = FactoryBot.create(:user, role: :admin)
     expect(user).not_to be_user
-    expect(user).not_to be_wimi
+    expect(user).not_to be_employee
     expect(user).to be_admin
   end
 

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Requests', type: :request do
   # Authenticate an user
   before do
-    user = FactoryBot.create :user, role: :wimi
+    user = FactoryBot.create :user, role: :employee
     sign_in user
   end
 

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -8,10 +8,10 @@ module ControllerMacros
     end
   end
 
-  def login_wimi
+  def login_employee
     before do
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      sign_in FactoryBot.create(:user, role: :wimi)
+      sign_in FactoryBot.create(:user, role: :employee)
     end
   end
 


### PR DESCRIPTION
Rename all occurences of wimi to employee, plain and simple. I do not think we need a database migration because the role field is just a plain integer, and only the rail translation is different.

Fixes #147 