### PR TITLE
Fix deploy script

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,7 @@ set :identity_file, '/home/hrmtadm/.ssh/id_rsa'
 
 set :shared_dirs, fetch(:shared_dirs, []).push('log', 'tmp/pids', 'tmp/sockets', 'public/uploads')
 set :shared_files, fetch(:shared_files, []).push('config/database.yml', 'config/puma.rb', 'config/master.key')
-set :rvm_use_path, '/usr/local/rvmsscripts/rvm'
+set :rvm_use_path, '/usr/local/rvm/scripts/rvm'
 # set :linked_files, %w{config/master.key}
 
 # Settings for Slack Integration


### PR DESCRIPTION
Fix `rvm_use_path` parameter in deployment script

Details:
https://github.com/hpi-swt2/vm-portal/commit/0332c4446b57b4542244cb598d46b38fca83910e#r31579865