### PR TITLE
Show only vms associated with the current user

### DIFF
--- a/app/api/vmapi.rb
+++ b/app/api/vmapi.rb
@@ -24,7 +24,8 @@ class VmApi
       { name: vm.name,
         state: (vm.runtime.powerState == 'poweredOn'),
         boot_time: vm.runtime.bootTime,
-        vmwaretools: (vm.guest.toolsStatus != 'toolsNotInstalled') }
+        vmwaretools: (vm.guest.toolsStatus != 'toolsNotInstalled'),
+        request: Request.find_by_name(vm.name) }
     end
   end
 
@@ -71,7 +72,9 @@ class VmApi
         host: vm.summary.runtime.host.name,
         guestHeartbeatStatus: vm.guestHeartbeatStatus,
         summary: vm.summary,
-        vmwaretools: (vm.guest.toolsStatus != 'toolsNotInstalled') }
+        vmwaretools: (vm.guest.toolsStatus != 'toolsNotInstalled'),
+        request: Request.find_by_name(vm.name)
+      }
     end
   end
 

--- a/app/controllers/vms_controller.rb
+++ b/app/controllers/vms_controller.rb
@@ -5,7 +5,7 @@ class VmsController < ApplicationController
   attr_reader :vms
 
   def index
-    @vms = filter VmApi.instance.all_vms
+    @vms = filter vms_for_user VmApi.instance.all_vms
     @parameters = determine_params
   end
 
@@ -63,6 +63,10 @@ class VmsController < ApplicationController
   # Because no Active Record model is being wrapped
 
   private
+
+  def vms_for_user(list)
+    list.select { |vm| !current_user.user? || (vm[:request] && vm[:request].users.include?(current_user)) }
+  end
 
   def filter(list)
     if no_params_set?

--- a/app/controllers/vms_controller.rb
+++ b/app/controllers/vms_controller.rb
@@ -25,6 +25,7 @@ class VmsController < ApplicationController
 
   def show
     @vm = VmApi.instance.get_vm(params[:id])
+    redirect_to vms_path unless !current_user.user? || (@vm[:request] && @vm[:request].users.include?(current_user))
     render(template: 'errors/not_found', status: :not_found) if @vm.nil?
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'vmapi.rb'
 class Request < ApplicationRecord
   has_many :users_assigned_to_requests
   has_many :users, through: :users_assigned_to_requests
@@ -22,6 +23,10 @@ class Request < ApplicationRecord
 
   def accept!
     self.status = 'accepted'
+  end
+
+  def vm
+    VmApi.instance.get_vm name if status == :accepted
   end
 
   private

--- a/spec/api/apiwrapper_spec.rb
+++ b/spec/api/apiwrapper_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe VmApi do
       mock = double
       summary = double
       guest = double
-      expect(mock).to receive(:name).and_return(vm_name)
+      allow(mock).to receive(:name).and_return(vm_name)
       allow(mock).to receive(:summary).and_return(summary)
       allow(summary).to receive_message_chain(:runtime, :host, :name).and_return('aHost')
       allow(mock).to receive_message_chain(:summary, :runtime, :host, :name).and_return('aHost')


### PR DESCRIPTION
If the current user is a simple user only show his vms on the vm index page.

Also add associations between vms and requests to determine which users belongs to which request.