### PR TITLE
255/oldies/redirect to page that triggered vm action

### DIFF
--- a/app/controllers/vms_controller.rb
+++ b/app/controllers/vms_controller.rb
@@ -71,31 +71,31 @@ class VmsController < ApplicationController
   def change_power_state
     @vm = VmApi.instance.get_vm_info(params[:id])
     VmApi.instance.change_power_state(@vm[:name], !@vm[:state])
-    redirect_to root_path
+    redirect_back(fallback_location: root_path)
   end
 
   def suspend_vm
     @vm = VmApi.instance.get_vm_info(params[:id])
     VmApi.instance.suspend_vm(@vm[:name])
-    redirect_to action: :show, id: params[:id]
+    redirect_back(fallback_location: root_path)
   end
 
   def shutdown_guest_os
     @vm = VmApi.instance.get_vm_info(params[:id])
     VmApi.instance.shutdown_guest_os(@vm[:name])
-    redirect_to action: :show, id: params[:id]
+    redirect_back(fallback_location: root_path)
   end
 
   def reboot_guest_os
     @vm = VmApi.instance.get_vm_info(params[:id])
     VmApi.instance.reboot_guest_os(@vm[:name])
-    redirect_to action: :show, id: params[:id]
+    redirect_back(fallback_location: root_path)
   end
 
   def reset_vm
     @vm = VmApi.instance.get_vm_info(params[:id])
     VmApi.instance.reset_vm(@vm[:name])
-    redirect_to action: :show, id: params[:id]
+    redirect_back(fallback_location: root_path)
   end
 
   # This controller doesn't use strong parameters

--- a/spec/controllers/vms_controller_spec.rb
+++ b/spec/controllers/vms_controller_spec.rb
@@ -205,11 +205,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:change_power_state)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
+      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
     end
 
-    it 'returns http success' do
+    it 'returns http success and redirects to previous location' do
       post :change_power_state, params: { id: 0 }
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to("where_i_came_from")
     end
   end
 
@@ -219,11 +220,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:suspend_vm)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
+      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
     end
 
-    it 'returns http success' do
+    it 'returns http success and redirects to previous location' do
       post :suspend_vm, params: { id: 0 }
-      expect(response).to redirect_to(vm_path)
+      expect(response).to redirect_to("where_i_came_from")
     end
   end
 
@@ -233,11 +235,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:shutdown_guest_os)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
+      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
     end
 
-    it 'returns http success' do
+    it 'returns http success and redirects to previous location' do
       post :shutdown_guest_os, params: { id: 0 }
-      expect(response).to redirect_to(vm_path)
+      expect(response).to redirect_to("where_i_came_from")
     end
   end
 
@@ -247,11 +250,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:reboot_guest_os)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
+      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
     end
 
-    it 'returns http success' do
+    it 'returns http success and redirects to previous location' do
       post :reboot_guest_os, params: { id: 0 }
-      expect(response).to redirect_to(vm_path)
+      expect(response).to redirect_to("where_i_came_from")
     end
   end
 
@@ -261,11 +265,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:reset_vm)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
+      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
     end
 
-    it 'returns http success' do
+    it 'returns http success and redirects to previous location' do
       post :reset_vm, params: { id: 0 }
-      expect(response).to redirect_to(vm_path)
+      expect(response).to redirect_to("where_i_came_from")
     end
   end
 end

--- a/spec/controllers/vms_controller_spec.rb
+++ b/spec/controllers/vms_controller_spec.rb
@@ -205,12 +205,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:change_power_state)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
-      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
+      request.env['HTTP_REFERER'] = 'where_i_came_from' unless request.nil? || request.env.nil?
     end
 
     it 'returns http success and redirects to previous location' do
       post :change_power_state, params: { id: 0 }
-      expect(response).to redirect_to("where_i_came_from")
+      expect(response).to redirect_to('where_i_came_from')
     end
   end
 
@@ -220,12 +220,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:suspend_vm)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
-      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
+      request.env['HTTP_REFERER'] = 'where_i_came_from' unless request.nil? || request.env.nil?
     end
 
     it 'returns http success and redirects to previous location' do
       post :suspend_vm, params: { id: 0 }
-      expect(response).to redirect_to("where_i_came_from")
+      expect(response).to redirect_to('where_i_came_from')
     end
   end
 
@@ -235,12 +235,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:shutdown_guest_os)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
-      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
+      request.env['HTTP_REFERER'] = 'where_i_came_from' unless request.nil? || request.env.nil?
     end
 
     it 'returns http success and redirects to previous location' do
       post :shutdown_guest_os, params: { id: 0 }
-      expect(response).to redirect_to("where_i_came_from")
+      expect(response).to redirect_to('where_i_came_from')
     end
   end
 
@@ -250,12 +250,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:reboot_guest_os)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
-      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
+      request.env['HTTP_REFERER'] = 'where_i_came_from' unless request.nil? || request.env.nil?
     end
 
     it 'returns http success and redirects to previous location' do
       post :reboot_guest_os, params: { id: 0 }
-      expect(response).to redirect_to("where_i_came_from")
+      expect(response).to redirect_to('where_i_came_from')
     end
   end
 
@@ -265,12 +265,12 @@ RSpec.describe VmsController, type: :controller do
       expect(double_api).to receive(:reset_vm)
       allow(VmApi).to receive(:instance).and_return double_api
       allow(double_api).to receive(:get_vm_info).and_return({})
-      request.env["HTTP_REFERER"] = "where_i_came_from" unless request.nil? or request.env.nil?
+      request.env['HTTP_REFERER'] = 'where_i_came_from' unless request.nil? || request.env.nil?
     end
 
     it 'returns http success and redirects to previous location' do
       post :reset_vm, params: { id: 0 }
-      expect(response).to redirect_to("where_i_came_from")
+      expect(response).to redirect_to('where_i_came_from')
     end
   end
 end


### PR DESCRIPTION

**Related User Story**: #255

**Description**

This MR will change the VM controller in such a way that it redirects to the page from which the request was triggered, falling back to the root path should a redirect not be possible. This was done using Rails 5s `redirect_back()`.

**Steps to reproduce**

To reproduce, simply trigger VM power actions from various places in the vm portal and observe that you are redirected to the page from where you triggered the request.

**Annex**

