### PR TITLE
fix puppet script icon

### DIFF
--- a/app/assets/stylesheets/vms.scss
+++ b/app/assets/stylesheets/vms.scss
@@ -79,7 +79,7 @@ h2{
 }
 
 .script-doc::before {
-  content: "\1F5CE";
+  content: "\1F4CE";
 }
 
 .btn-manage {

--- a/app/assets/stylesheets/vms.scss
+++ b/app/assets/stylesheets/vms.scss
@@ -93,6 +93,7 @@ h2{
 .btn-manage:hover {
   text-decoration: none;
   color: black;
+  filter: drop-shadow(2px 2px 1px $secondary);
 }
 
 .filter-box {


### PR DESCRIPTION
**Description**
This PR will change the icon linking to the puppet script to a unicode char which is also available on UNIX systems (U+1F4CE).

[//]: # (Describe the new feature and how you've implemented it)

**Steps to reproduce**
Change the ::before content in the stylesheet.

**Annex**
![screenshot_2019-01-31 vmportal](https://user-images.githubusercontent.com/27929897/52058003-cf84f580-2566-11e9-9d70-89346fecbadb.png)

