### PR TITLE
304 - Tackles the webkit-issue by adding another POST-based route for logout

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -46,7 +46,7 @@
         </a>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
           <%= link_to('Profile', user_path(current_user), class: "dropdown-item") %>
-          <%= link_to('Logout', destroy_user_session_path, method: :delete, class: "text-danger dropdown-item") %>
+          <%= link_to('Logout', new_sign_out_path, method: :post, class: "text-danger dropdown-item") %>
         </div>
       </li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Rails.application.routes.draw do
   get 'slack/new' => 'slack#new', as: :new_slack
   get 'slack/auth' => 'slack#update', as: :update_slack
 
+  devise_scope :user do # temporary fix related to GitHub issue 304
+    post '/users/new_sign_out' => 'devise/sessions#destroy', as: :new_sign_out
+  end
   devise_for :users,
              path: 'users',
              controllers: {

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,8 @@ ActiveRecord::Schema.define(version: 2019_02_01_091109) do
     t.datetime "updated_at", null: false
     t.integer "port"
     t.string "application_name"
-    t.integer "user_id"
     t.text "description"
+    t.integer "user_id"
     t.index ["user_id"], name: "index_requests_on_user_id"
   end
 
@@ -129,11 +129,11 @@ ActiveRecord::Schema.define(version: 2019_02_01_091109) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "role"
-    t.string "first_name"
-    t.string "last_name"
-    t.string "ssh_key"
     t.string "provider"
     t.string "uid"
+    t.string "ssh_key"
+    t.string "first_name"
+    t.string "last_name"
     t.integer "user_id"
     t.boolean "email_notifications", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -146,8 +146,6 @@ ActiveRecord::Schema.define(version: 2019_02_01_091109) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["request_id"], name: "index_users_assigned_to_requests_on_request_id"
-    t.index ["user_id"], name: "index_users_assigned_to_requests_on_user_id"
   end
 
   create_table "users_virtual_machine_configs", id: false, force: :cascade do |t|

--- a/spec/features/sessions/user_sign_out_spec.rb
+++ b/spec/features/sessions/user_sign_out_spec.rb
@@ -9,7 +9,7 @@ describe 'Sign Out', type: :feature do
   end
 
   it 'has a logout button' do
-    expect(page).to have_link 'Logout', href: destroy_user_session_path
+    expect(page).to have_link 'Logout', href: new_sign_out_path
   end
 
   it 'logs out the user' do


### PR DESCRIPTION
**Description**
This is considered to be a temporary fix. Since the issues described in #304 are not reproducible locally and changes can't be applied immediately to the dev system, we have to check this approach by just deploying it. I've tested it locally and it does not break the system. It uses the new route, that's tested. 

My approach is to add a new route which uses directly a `POST` request instead of a `DELETE` request to sign out the user as described [here](https://stackoverflow.com/questions/38806160/rails-devise-sign-out-not-working-in-safari). I've read that DELETE requests may cause errors in some browsers. Therefore, avoiding them could fix this issue.

**Related Issue:** GH-304

**TODO:**

When this test is successful and logout works for Safari and Chrome, this fix must be applied for all other affected routes/actions, as well. 