### PR TITLE
Vertical/minifixes

### DIFF
--- a/app/controllers/operating_systems_controller.rb
+++ b/app/controllers/operating_systems_controller.rb
@@ -2,6 +2,7 @@
 
 class OperatingSystemsController < ApplicationController
   before_action :set_operating_system, only: %i[edit update destroy]
+  before_action :authenticate_admin
 
   # GET /operating_systems
   # GET /operating_systems.json

--- a/app/controllers/request_templates_controller.rb
+++ b/app/controllers/request_templates_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class RequestTemplatesController < ApplicationController
-  before_action :authenticate_admin, only: %i[new edit create update destroy]
   before_action :set_request_template, only: %i[show edit update destroy]
+  before_action :authenticate_admin
 
   # GET /request_templates
   # GET /request_templates.json

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class ServersController < ApplicationController
-  
-  before_action :authenticate_employee, only: %i[show]
+  before_action :authenticate_employee
   before_action :authenticate_admin, only: %i[new create edit update destroy]
   # GET /servers
   # GET /servers.json

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ServersController < ApplicationController
-  before_action :set_server, only: %i[show edit update destroy]
+  
   before_action :authenticate_employee, only: %i[show]
   before_action :authenticate_admin, only: %i[new create edit update destroy]
   # GET /servers

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ServersController < ApplicationController
-  before_action :authenticate_employee
+  before_action :set_server, only: %i[show edit update destroy]
+  before_action :authenticate_employee, only: %i[show index]
   before_action :authenticate_admin, only: %i[new create edit update destroy]
   # GET /servers
   # GET /servers.json

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -18,9 +18,11 @@
             <%= link_to('Hosts', hosts_path, class: "nav-link") %>
           </li>
         <% end %>
+        <% if current_user.employee_or_admin? %>
         <li class="nav-item">
           <%= link_to('Servers', servers_path, class: "nav-link") %>
         </li>
+        <% end %>
         <li class="nav-item">
           <%= link_to('Projects', projects_path, class: "nav-link") %>
         </li>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,10 +1,8 @@
 <div class="clearfix">
   <h1 class="float-left">Requests</h1>
-  <% if current_user.employee_or_admin? %>
   <%= link_to fa_icon('plus'), new_request_path,
     method: :get,
     class: "btn btn-primary float-right mt-3" %>
-  <% end %>
   <% if current_user.admin? %>
   <%= button_to "Templates", request_templates_path,
     method: :get,

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,14 +1,18 @@
 <div class="clearfix">
   <h1 class="float-left">Requests</h1>
+  <% if current_user.employee_or_admin? %>
   <%= link_to fa_icon('plus'), new_request_path,
     method: :get,
     class: "btn btn-primary float-right mt-3" %>
+  <% end %>
+  <% if current_user.admin? %>
   <%= button_to "Templates", request_templates_path,
     method: :get,
     class: "btn btn-primary float-right mt-3 mr-3" %>
   <%= button_to 'Operating Systems', operating_systems_path,
     method: :get,
     class: 'btn btn-primary float-right mt-3 mr-3' %>
+  <% end %>
 </div>
 
 <%= link_to "Pending requests (#{@pending_requests&.size}) <small>&#x25bc;</small>".html_safe, '#pending' %><br />

--- a/spec/controllers/operating_systems_controller_spec.rb
+++ b/spec/controllers/operating_systems_controller_spec.rb
@@ -46,98 +46,124 @@ RSpec.describe OperatingSystemsController, type: :controller do
   # OperatingSystemsController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  before do
-    sign_in FactoryBot.create :user
-  end
-
-  describe 'GET #index' do
-    it 'returns a success response' do
-      OperatingSystem.create! valid_attributes
-      get :index, params: {}, session: valid_session
-      expect(response).to be_successful
+  context 'if current_user is admin' do
+    before do
+      sign_in FactoryBot.create :admin
     end
-  end
 
-  describe 'GET #new' do
-    it 'returns a success response' do
-      get :new, params: {}, session: valid_session
-      expect(response).to be_successful
+    describe 'GET #index' do
+      it 'returns a success response' do
+        OperatingSystem.create! valid_attributes
+        get :index, params: {}, session: valid_session
+        expect(response).to be_successful
+      end
     end
-  end
 
-  describe 'GET #edit' do
-    it 'returns a success response' do
-      operating_system = OperatingSystem.create! valid_attributes
-      get :edit, params: { id: operating_system.to_param }, session: valid_session
-      expect(response).to be_successful
+    describe 'GET #new' do
+      it 'returns a success response' do
+        get :new, params: {}, session: valid_session
+        expect(response).to be_successful
+      end
     end
-  end
 
-  describe 'POST #create' do
-    context 'with valid params' do
-      it 'creates a new OperatingSystem' do
-        expect do
+    describe 'GET #edit' do
+      it 'returns a success response' do
+        operating_system = OperatingSystem.create! valid_attributes
+        get :edit, params: { id: operating_system.to_param }, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+
+    describe 'POST #create' do
+      context 'with valid params' do
+        it 'creates a new OperatingSystem' do
+          expect do
+            post :create, params: { operating_system: valid_attributes }, session: valid_session
+          end.to change(OperatingSystem, :count).by(1)
+        end
+
+        it 'redirects to the created operating_system' do
           post :create, params: { operating_system: valid_attributes }, session: valid_session
-        end.to change(OperatingSystem, :count).by(1)
+          expect(response).to redirect_to(operating_systems_url)
+        end
       end
 
-      it 'redirects to the created operating_system' do
-        post :create, params: { operating_system: valid_attributes }, session: valid_session
-        expect(response).to redirect_to(operating_systems_url)
+      context 'with invalid params' do
+        it "returns a success response (i.e. to display the 'new' template)" do
+          post :create, params: { operating_system: invalid_attributes }, session: valid_session
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    describe 'PUT #update' do
+      context 'with valid params' do
+        let(:new_attributes) do
+          {
+            name: 'MyNewOS'
+          }
+        end
+
+        it 'updates the requested operating_system' do
+          operating_system = OperatingSystem.create! valid_attributes
+          put :update, params: { id: operating_system.to_param, operating_system: new_attributes }, session: valid_session
+          operating_system.reload
+          expect(operating_system.name).to eq('MyNewOS')
+        end
+
+        it 'redirects to the operating_system' do
+          operating_system = OperatingSystem.create! valid_attributes
+          put :update, params: { id: operating_system.to_param, operating_system: valid_attributes }, session: valid_session
+          expect(response).to redirect_to(operating_systems_url)
+        end
+      end
+
+      context 'with invalid params' do
+        it "returns a success response (i.e. to display the 'edit' template)" do
+          operating_system = OperatingSystem.create! valid_attributes
+          put :update, params: { id: operating_system.to_param, operating_system: invalid_attributes }, session: valid_session
+          expect(response).to be_successful
+        end
       end
     end
 
-    context 'with invalid params' do
-      it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: { operating_system: invalid_attributes }, session: valid_session
-        expect(response).to be_successful
-      end
-    end
-  end
-
-  describe 'PUT #update' do
-    context 'with valid params' do
-      let(:new_attributes) do
-        {
-          name: 'MyNewOS'
-        }
-      end
-
-      it 'updates the requested operating_system' do
+    describe 'DELETE #destroy' do
+      it 'destroys the requested operating_system' do
         operating_system = OperatingSystem.create! valid_attributes
-        put :update, params: { id: operating_system.to_param, operating_system: new_attributes }, session: valid_session
-        operating_system.reload
-        expect(operating_system.name).to eq('MyNewOS')
+        expect do
+          delete :destroy, params: { id: operating_system.to_param }, session: valid_session
+        end.to change(OperatingSystem, :count).by(-1)
       end
 
-      it 'redirects to the operating_system' do
+      it 'redirects to the operating_systems list' do
         operating_system = OperatingSystem.create! valid_attributes
-        put :update, params: { id: operating_system.to_param, operating_system: valid_attributes }, session: valid_session
-        expect(response).to redirect_to(operating_systems_url)
-      end
-    end
-
-    context 'with invalid params' do
-      it "returns a success response (i.e. to display the 'edit' template)" do
-        operating_system = OperatingSystem.create! valid_attributes
-        put :update, params: { id: operating_system.to_param, operating_system: invalid_attributes }, session: valid_session
-        expect(response).to be_successful
-      end
-    end
-  end
-
-  describe 'DELETE #destroy' do
-    it 'destroys the requested operating_system' do
-      operating_system = OperatingSystem.create! valid_attributes
-      expect do
         delete :destroy, params: { id: operating_system.to_param }, session: valid_session
-      end.to change(OperatingSystem, :count).by(-1)
+        expect(response).to redirect_to(operating_systems_url)
+      end
+    end
+  end
+  context 'if current_user is user' do
+    before do
+      sign_in FactoryBot.create :user
+      get :index
     end
 
-    it 'redirects to the operating_systems list' do
-      operating_system = OperatingSystem.create! valid_attributes
-      delete :destroy, params: { id: operating_system.to_param }, session: valid_session
-      expect(response).to redirect_to(operating_systems_url)
+    describe 'GET #index if user is logged in' do
+      it 'returns http redirect' do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+  context 'if current_user is employee' do
+    before do
+      sign_in FactoryBot.create :employee
+      get :index
+    end
+
+    describe 'GET #index if employee is logged in' do
+      it 'returns http redirect' do
+        expect(response).to have_http_status(:redirect)
+      end
     end
   end
 end

--- a/spec/controllers/request_templates_controller_spec.rb
+++ b/spec/controllers/request_templates_controller_spec.rb
@@ -26,10 +26,6 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe RequestTemplatesController, type: :controller do
-  before do
-    sign_in current_user
-  end
-
   # This should return the minimal set of attributes required to create a valid
   # RequestTemplate. As you add validations to RequestTemplate, be sure to
   # adjust the attributes here as well.
@@ -58,173 +54,103 @@ RSpec.describe RequestTemplatesController, type: :controller do
   # RequestTemplatesController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  context 'when the current_user is an user' do
-    let(:current_user) { FactoryBot.create :user }
+  before do
+    sign_in FactoryBot.create :admin
+  end
 
-    describe 'GET #index' do
-      it 'returns a success response' do
-        RequestTemplate.create! valid_attributes
-        get :index, params: {}, session: valid_session
-        expect(response).to be_successful
-      end
-    end
-
-    describe 'GET #new' do
-      it 'returns a no success response' do
-        get :new, params: {}, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'GET #edit' do
-      it 'returns a no success response' do
-        request_template = RequestTemplate.create! valid_attributes
-        get :edit, params: { id: request_template.to_param }, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'POST #create' do
-      it 'returns a no success response' do
-        post :create, params: { request_template: valid_attributes }, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'PUT #update' do
-      it 'returns a no success response' do
-        request_template = RequestTemplate.create! valid_attributes
-        put :update, params: { id: request_template.to_param, request_template: invalid_attributes }, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'DELETE #destroy' do
-      it 'returns a no success response' do
-        request_template = RequestTemplate.create! valid_attributes
-        delete :destroy, params: { id: request_template.to_param }, session: valid_session
-        expect(response).not_to be_successful
-      end
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to be_successful
     end
   end
 
-  context 'when the current_user is an employee' do
-    let(:current_user) { FactoryBot.create :employee }
-
-    describe 'GET #index' do
-      it 'returns a success response' do
-        RequestTemplate.create! valid_attributes
-        get :index, params: {}, session: valid_session
-        expect(response).to be_successful
-      end
-    end
-
-    describe 'GET #new' do
-      it 'returns a no success response' do
-        get :new, params: {}, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'GET #edit' do
-      it 'returns a no success response' do
-        request_template = RequestTemplate.create! valid_attributes
-        get :edit, params: { id: request_template.to_param }, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'POST #create' do
-      it 'returns a no success response' do
-        post :create, params: { request_template: valid_attributes }, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'PUT #update' do
-      it 'returns a no success response' do
-        request_template = RequestTemplate.create! valid_attributes
-        put :update, params: { id: request_template.to_param, request_template: invalid_attributes }, session: valid_session
-        expect(response).not_to be_successful
-      end
-    end
-
-    describe 'DELETE #destroy' do
-      it 'returns a no success response' do
-        request_template = RequestTemplate.create! valid_attributes
-        delete :destroy, params: { id: request_template.to_param }, session: valid_session
-        expect(response).not_to be_successful
-      end
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      request_template = RequestTemplate.create! valid_attributes
+      get :edit, params: { id: request_template.to_param }, session: valid_session
+      expect(response).to be_successful
     end
   end
 
-  context 'when the current_user is an admin' do
-    let(:current_user) { FactoryBot.create :admin }
-
-    describe 'GET #new' do
-      it 'returns a success response' do
-        get :new, params: {}, session: valid_session
-        expect(response).to be_successful
-      end
-    end
-
-    describe 'GET #edit' do
-      it 'returns a success response' do
-        request_template = RequestTemplate.create! valid_attributes
-        get :edit, params: { id: request_template.to_param }, session: valid_session
-        expect(response).to be_successful
-      end
-    end
-
-    describe 'POST #create' do
-      context 'with valid params' do
-        it 'creates a new RequestTemplate' do
-          expect do
-            post :create, params: { request_template: valid_attributes }, session: valid_session
-          end.to change(RequestTemplate, :count).by(1)
-        end
-      end
-
-      context 'with invalid params' do
-        it "returns a success response (i.e. to display the 'new' template)" do
-          post :create, params: { request_template: invalid_attributes }, session: valid_session
-          expect(response).to be_successful
-        end
-      end
-    end
-
-    describe 'PUT #update' do
-      context 'with valid params' do
-        let(:new_attributes) do
-          {
-            name: 'newName'
-          }
-        end
-
-        it 'updates the requested request_template' do
-          request_template = RequestTemplate.create! valid_attributes
-          put :update, params: { id: request_template.to_param, request_template: new_attributes }, session: valid_session
-          request_template.reload
-          expect(request_template.name).to eq 'newName'
-        end
-      end
-
-      context 'with invalid params' do
-        it "returns a success response (i.e. to display the 'edit' template)" do
-          request_template = RequestTemplate.create! valid_attributes
-          put :update, params: { id: request_template.to_param, request_template: invalid_attributes }, session: valid_session
-          expect(response).to be_successful
-        end
-      end
-    end
-
-    describe 'DELETE #destroy' do
-      it 'destroys the requested request_template' do
-        request_template = RequestTemplate.create! valid_attributes
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new RequestTemplate' do
         expect do
-          delete :destroy, params: { id: request_template.to_param }, session: valid_session
-        end.to change(RequestTemplate, :count).by(-1)
+          post :create, params: { request_template: valid_attributes }, session: valid_session
+        end.to change(RequestTemplate, :count).by(1)
       end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { request_template: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        {
+          name: 'newName'
+        }
+      end
+
+      it 'updates the requested request_template' do
+        request_template = RequestTemplate.create! valid_attributes
+        put :update, params: { id: request_template.to_param, request_template: new_attributes }, session: valid_session
+        request_template.reload
+        expect(request_template.name).to eq 'newName'
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        request_template = RequestTemplate.create! valid_attributes
+        put :update, params: { id: request_template.to_param, request_template: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested request_template' do
+      request_template = RequestTemplate.create! valid_attributes
+      expect do
+        delete :destroy, params: { id: request_template.to_param }, session: valid_session
+      end.to change(RequestTemplate, :count).by(-1)
+    end
+  end
+end
+
+RSpec.describe RequestTemplatesController, type: :controller do
+  let(:valid_session) { {} }
+
+  before do
+    sign_in FactoryBot.create :user
+    get :index
+  end
+
+  describe 'GET #index if user is logged in' do
+    it 'returns http redirect' do
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end
+
+RSpec.describe RequestTemplatesController, type: :controller do
+  let(:valid_session) { {} }
+
+  before do
+    sign_in FactoryBot.create :employee
+    get :index
+  end
+
+  describe 'GET #index if employee is logged in' do
+    it 'returns http redirect' do
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/controllers/servers_controller_spec.rb
+++ b/spec/controllers/servers_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ServersController, type: :controller do
 
   let(:valid_session) { {} }
 
-  # Authenticate an user
+  # Authenticate an admin
   before do
     sign_in FactoryBot.create :admin
   end
@@ -156,12 +156,12 @@ RSpec.describe ServersController, type: :controller do
   # Authenticate an user
   before do
     sign_in FactoryBot.create :user
+    get :index
   end
 
-  describe 'GET #index' do
-    it 'returns a success response' do
-      get :new, params: {}, session: valid_session
-      expect(response).to redirect_to(dashboard_path)
+  describe 'GET #index if user is logged in' do
+    it 'returns http redirect' do
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/requests/operating_systems_spec.rb
+++ b/spec/requests/operating_systems_spec.rb
@@ -3,14 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe 'OperatingSystems', type: :request do
-  describe 'GET /operating_systems' do
+  describe 'GET /operating_systems as admin' do
     before do
-      sign_in FactoryBot.create :user
+      sign_in FactoryBot.create :admin
     end
 
     it 'works! (now write some real specs)' do
       get operating_systems_path
       expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /operating_systems as user' do
+    before do
+      sign_in FactoryBot.create :user
+    end
+
+    it 'does not work! (now write some real specs)' do
+      get operating_systems_path
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe 'GET /operating_systems as employee' do
+    before do
+      sign_in FactoryBot.create :employee
+    end
+
+    it 'does not work! (now write some real specs)' do
+      get operating_systems_path
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/requests/request_templates_spec.rb
+++ b/spec/requests/request_templates_spec.rb
@@ -3,14 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe 'RequestTemplates', type: :request do
-  before do
-    sign_in FactoryBot.create :user
-  end
-
   describe 'GET /request_templates' do
+    before do
+      sign_in FactoryBot.create :admin
+    end
+
     it 'works! (now write some real specs)' do
       get request_templates_path
       expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /request_templates as user' do
+    before do
+      sign_in FactoryBot.create :user
+    end
+
+    it 'does not work! (now write some real specs)' do
+      get request_templates_path
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe 'GET /request_templates as employee' do
+    before do
+      sign_in FactoryBot.create :employee
+    end
+
+    it 'does not work! (now write some real specs)' do
+      get request_templates_path
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -3,13 +3,34 @@
 require 'rails_helper'
 
 RSpec.describe 'Requests', type: :request do
-  # Authenticate an user
-  before do
-    user = FactoryBot.create :user, role: :employee
-    sign_in user
+  describe 'GET /requests' do
+    before do
+      user = FactoryBot.create :admin
+      sign_in user
+    end
+
+    it 'works! (now write some real specs)' do
+      get requests_path
+      expect(response).to have_http_status(200)
+    end
   end
 
-  describe 'GET /requests' do
+  describe 'GET /requests as user' do
+    before do
+      sign_in FactoryBot.create :user
+    end
+
+    it 'does not work! (now write some real specs)' do
+      get requests_path
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe 'GET /requests as employee' do
+    before do
+      sign_in FactoryBot.create :employee
+    end
+
     it 'works! (now write some real specs)' do
       get requests_path
       expect(response).to have_http_status(200)

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -3,9 +3,31 @@
 require 'rails_helper'
 
 RSpec.describe 'Servers', type: :request do
-  describe 'GET /servers' do
+  describe 'GET /servers as admin' do
+    before do
+      sign_in FactoryBot.create :admin
+    end
+
+    it 'works! (now write some real specs)' do
+      get servers_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /servers as user' do
     before do
       sign_in FactoryBot.create :user
+    end
+
+    it 'does not work! (now write some real specs)' do
+      get servers_path
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe 'GET /servers as employee' do
+    before do
+      sign_in FactoryBot.create :employee
     end
 
     it 'works! (now write some real specs)' do

--- a/spec/views/application/_navbar.html.erb_spec.rb
+++ b/spec/views/application/_navbar.html.erb_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'application/_navbar.html.erb', type: :view do
       expect(rendered).to have_link('Profile', href: user_path(current_user))
     end
 
-    it 'links to servers list' do
-      expect(rendered).to have_link('Servers', href: servers_path)
+    it 'does not link to servers list' do
+      expect(rendered).not_to have_link('Servers', href: servers_path)
     end
 
     it 'links to the Notification Page' do
@@ -37,6 +37,38 @@ RSpec.describe 'application/_navbar.html.erb', type: :view do
 
     it 'does not link to users list' do
       expect(rendered).not_to have_link('Users', href: users_path)
+    end
+  end
+
+  context 'when the current user is an employee' do
+    let(:current_user) { FactoryBot.create :employee }
+
+    it 'does not link to host list' do
+      expect(rendered).not_to have_link('Hosts', href: hosts_path)
+    end
+
+    it 'links to the current user profile' do
+      expect(rendered).to have_link('Profile', href: user_path(current_user))
+    end
+
+    it 'links to the Notification Page' do
+      expect(rendered).to have_link(href: notifications_path)
+    end
+
+    it 'links to vm list' do
+      expect(rendered).to have_link('VMs', href: vms_path)
+    end
+
+    it 'links to the project list' do
+      expect(rendered).to have_link('Projects', href: projects_path)
+    end
+
+    it 'does not link to users list' do
+      expect(rendered).not_to have_link('Users', href: users_path)
+    end
+
+    it 'links to servers list' do
+      expect(rendered).to have_link('Servers', href: servers_path)
     end
   end
 

--- a/spec/views/requests/index.html.erb_spec.rb
+++ b/spec/views/requests/index.html.erb_spec.rb
@@ -8,6 +8,37 @@ RSpec.describe 'requests/index', type: :view do
   end
 
   before do
+    sign_in FactoryBot.create :admin
+    assign(:pending_requests, requests)
+    assign(:resolved_requests, requests)
+    render
+  end
+
+  it 'renders a list of all requests' do
+    assert_select 'tr>td', text: 'myvm'.to_s, count: 2
+    assert_select 'tr>td', text: 'myvm1'.to_s, count: 2
+    assert_select 'tr>td', text: 2.to_s, count: 4
+    assert_select 'tr>td', text: '1 GB', count: 4
+    assert_select 'tr>td', text: '3 GB', count: 4
+    assert_select 'tr>td', text: 'MyOS'.to_s, count: 4
+    assert_select 'tr>td', text: 4000.to_s, count: 4
+    assert_select 'tr>td', text: 'MyName'.to_s, count: 4
+    assert_select 'tr>td', text: 'Comment'.to_s, count: 4
+  end
+
+  it 'has a link to edit the request status' do
+    expect(rendered).to have_link(href: request_path(requests[0]))
+    expect(rendered).to have_link(href: request_path(requests[1]))
+  end
+end
+
+RSpec.describe 'requests/index', type: :view do
+  let(:requests) do
+    [FactoryBot.create(:request), FactoryBot.create(:request, name: 'myvm1')]
+  end
+
+  before do
+    sign_in FactoryBot.create :employee
     assign(:pending_requests, requests)
     assign(:resolved_requests, requests)
     render


### PR DESCRIPTION
- Restrict access to servers for users
- Restrict access to operating systems for users & employees
- Restrict access to request templates for users & employees

- Remove operating system button on requests page for users & employees
- Remove request templates button on requests page for users & employees