### PR TITLE
#453/rspec deprecation

### DIFF
--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DashboardController, type: :controller do
     context 'when logged out' do
       it 'redirects to the login page' do
         get(:index)
-        response.should redirect_to('/users/sign_in')
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end

--- a/spec/controllers/landing_controller_spec.rb
+++ b/spec/controllers/landing_controller_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe LandingController, type: :controller do
 
       it 'redirects to dashboard' do
         get(:index)
-        response.should redirect_to('/dashboard')
+        expect(response).to redirect_to(dashboard_path)
       end
     end
 
     context 'when logged out' do
       it 'redirects to login page' do
         get(:index)
-        response.should redirect_to('/users/sign_in')
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end

--- a/spec/features/slack/slack_controller_spec.rb
+++ b/spec/features/slack/slack_controller_spec.rb
@@ -46,7 +46,8 @@ describe SlackController do
     auth_request = mock_auth_request
 
     error_message = 'My Error'
-    described_class.any_instance.stub(:authenticate_request).and_return('ok' => false, 'error' => error_message)
+    # https://www.rubydoc.info/github/rspec/rspec-mocks/RSpec/Mocks/ExampleMethods%3aallow_any_instance_of
+    allow_any_instance_of(described_class).to receive(:authenticate_request).and_return('ok' => false, 'error' => error_message)
     # see https://api.slack.com/methods/oauth.access for the protocol of the mocked api
 
     visit update_slack_path(state: auth_request.state, code: 'We must provide a code')
@@ -56,8 +57,7 @@ describe SlackController do
 
   it 'shows success message' do
     auth_request = mock_auth_request
-
-    described_class.any_instance.stub(:authenticate_request).and_return('incoming_webhook' => { 'url' => 'My URL' })
+    allow_any_instance_of(described_class).to receive(:authenticate_request).and_return('incoming_webhook' => { 'url' => 'My URL' })
     # see https://api.slack.com/methods/oauth.access for the protocol of the mocked api
 
     visit update_slack_path(state: auth_request.state, code: 'We must provide a code')
@@ -69,7 +69,7 @@ describe SlackController do
     auth_request = mock_auth_request
 
     webhook_url = 'My URL'
-    described_class.any_instance.stub(:authenticate_request).and_return('incoming_webhook' => { 'url' => webhook_url })
+    allow_any_instance_of(described_class).to receive(:authenticate_request).and_return('incoming_webhook' => { 'url' => webhook_url })
     # see https://api.slack.com/methods/oauth.access for the protocol of the mocked api
 
     visit update_slack_path(state: auth_request.state, code: 'We must provide a code')


### PR DESCRIPTION
Refactored deprecated RSpec functions `should` and `allow_any_instance_of`