### PR TITLE
497/Extract form error display into partial

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,15 @@ $primary-hover: #1a5b82;
 //@import 'datatables/extensions/Scroller/scroller.bootstrap4';
 //@import 'datatables/extensions/Select/select.bootstrap4';
 
+// https://guides.rubyonrails.org/v3.2/active_record_validations_callbacks.html#customizing-error-messages-css
+.field_with_errors > label {
+  color: $danger;
+}
+
+.field_with_errors > * {
+  @extend .is-invalid;
+}
+
 th {
   @extend .text-white;
   @extend .bg-primary;

--- a/app/views/app_settings/_form.html.erb
+++ b/app/views/app_settings/_form.html.erb
@@ -1,15 +1,5 @@
 <%= form_with(model: app_setting, local: true, builder: HartFormBuilder) do |form| %>
-  <% if app_setting.errors.any? %>
-    <div id="error_explanation" class="alert alert-danger">
-      <h2><%= pluralize(app_setting.errors.count, "error") %> prohibited the Settings from being saved:</h2>
-
-      <ul>
-        <% app_setting.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/form_errors', model: form.object %>
 
   <div class="container-fluid styled-form">
     <div class="row border-bottom mb-4 pb-4">

--- a/app/views/layouts/_form_errors.html.erb
+++ b/app/views/layouts/_form_errors.html.erb
@@ -1,6 +1,6 @@
 <% if model.errors.any? %>
   <div id="error_explanation" class="alert alert-danger">
-    <h2><%= pluralize(model.errors.count, "error") %> prohibited the <%= model.model_name.human %> from being saved:</h2>
+    <h5><%= pluralize(model.errors.count, "error") %> prohibited the <%= model.model_name.human %> from being saved:</h5>
     <ul>
       <% model.errors.full_messages.each do |message| %>
           <li><%= message %></li>

--- a/app/views/layouts/_form_errors.html.erb
+++ b/app/views/layouts/_form_errors.html.erb
@@ -1,0 +1,11 @@
+<% if model.errors.any? %>
+  <div id="error_explanation" class="alert alert-danger">
+    <h2><%= pluralize(model.errors.count, "error") %> prohibited the <%= model.model_name.human %> from being saved:</h2>
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+

--- a/app/views/operating_systems/_form.html.erb
+++ b/app/views/operating_systems/_form.html.erb
@@ -1,15 +1,5 @@
 <%= form_with(model: operating_system, local: true) do |form| %>
-  <% if operating_system.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(operating_system.errors.count, "error") %> prohibited this operating_system from being saved:</h2>
-
-      <ul>
-      <% operating_system.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/form_errors', model: form.object %>
 
   <div class="field">
     <%= form.label :name %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,15 +1,5 @@
 <%= form_with(model: project, local: true) do |form| %>
-  <% if project.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(project.errors.count, "error") %> prohibited this project from being saved:</h2>
-
-      <ul>
-        <% project.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/form_errors', model: form.object %>
 
   <div class="field form-group">
     <%= form.label :name %>

--- a/app/views/request_templates/_form.html.erb
+++ b/app/views/request_templates/_form.html.erb
@@ -1,15 +1,5 @@
 <%= form_with(model: request_template, local: true) do |form| %>
-  <% if request_template.errors.any? %>
-    <div id="error_explanation" class="alert alert-danger">
-      <h2><%= pluralize(request_template.errors.count, "error") %> prohibited this request template from being saved:</h2>
-
-      <ul>
-      <% request_template.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/form_errors', model: form.object %>
 
   <div class="field form-group">
     <%= form.label 'Template name' %>

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -1,14 +1,5 @@
 <%= form_with(model: request, local: true) do |form| %>
-  <% if request.errors.any? %>
-    <div id="error_explanation" class="alert alert-danger">
-      <h2><%= pluralize(request.errors.count, "error") %> prohibited this request from being saved:</h2>
-      <ul>
-        <% request.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/form_errors', model: form.object %>
 
   <div class="container-fluid styled-form">
     <div class="row border-bottom mb-4 pb-4">

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -1,15 +1,5 @@
 <%= form_with(model: server, local: true) do |form| %>
-  <% if server.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(server.errors.count, "error") %> prohibited this server from being saved:</h2>
-
-      <ul>
-      <% server.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'layouts/form_errors', model: form.object %>
 
   <div class="field form-group">
     <%= form.label :name %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,18 +1,8 @@
-<% if @user.errors.any? %>
-  <div id="errors">
-    <% @user.errors.messages.values.each do |messages| %>
-      <% messages.each do |message| %>
-        <div class="alert alert-danger">
-          <%= message %>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
-<% end %>
-
-<h1>User profile</h1><br>
+<h1>User profile</h1>
 
 <%= form_for @user do |form| %>
+  <%= render 'layouts/form_errors', model: form.object %>
+
   <table class="table">
     <tbody>
       <tr>
@@ -32,7 +22,7 @@
         <td><%= form.check_box :email_notifications %></td>
       </tr>
     </tbody>
-  </table><br>
+  </table>
 
   <button type='submit',
   class='btn btn-primary float-right',


### PR DESCRIPTION
**EDIT**: Most likely replaced by https://github.com/hpi-swt2/vm-portal/pull/525

* Create shared form error partial
* Replace duplicated code
* Add CSS to Bootstrap style the `field_with_errors` classes that RoR adds

https://github.com/hpi-swt2/vm-portal/issues/497

![image](https://user-images.githubusercontent.com/1652117/55030376-8acc8680-500c-11e9-8eb1-417e7ab01797.png)
